### PR TITLE
Integrate API and Tests

### DIFF
--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   
   mongodb:
     image: mongo:latest
-    container_name: mongo
+    container_name: agenda-mongo
     volumes:
       - mongodb-data:/data/db
     ports:

--- a/api/test/tests/controllers/participant.js
+++ b/api/test/tests/controllers/participant.js
@@ -1,8 +1,9 @@
-const assert       = require( "assert" );
-const dbUtils      = require( "../../utils/db" );
-const db           = require( "../../../lib/db" );
-const ObjectID     = require( "mongoose" ).Types.ObjectId;
-const axios        = require( "axios" );
+const assert   = require( "assert" );
+const dbUtils  = require( "../../utils/db" );
+const db       = require( "../../../lib/db" );
+const api      = require( "../../utils/api" );
+const ObjectID = require( "mongoose" ).Types.ObjectId;
+const axios    = require( "axios" );
 
 const participant = {
   firstName: "linus",
@@ -11,9 +12,11 @@ const participant = {
   meeting_id: new ObjectID
 };
 
+
 describe.only( "controllers/participant", () => {
 
   before( async() => {
+    await api.start();
     await db.connect();
   });
 
@@ -22,6 +25,7 @@ describe.only( "controllers/participant", () => {
   });
 
   after( async() => {
+    await api.stop();
     await db.disconnect();
   });
 
@@ -32,7 +36,7 @@ describe.only( "controllers/participant", () => {
       const res = await axios.post( path, participant );
 
       assert(
-        res.status === 200,
+        res.status === 201,
         "failed to create participant with valid args"
       );
     });

--- a/api/test/utils/api.js
+++ b/api/test/utils/api.js
@@ -1,0 +1,37 @@
+const express  = require( "express" );
+const router   = require( "../../lib/routes" );
+
+const app      = express();
+
+let server;
+
+const api = {
+  start: async() => {
+    try {
+      app.use( express.json() );
+      app.use( express.urlencoded({ extended: true }) );
+
+      app.use( "/", router );
+
+      const port = process.env.PORT || 5000;
+
+      server = app.listen( port );
+
+    } catch ( error ) {
+
+      console.error( "agenda api failed to start: " + error.message );
+    }
+  },
+
+  stop: async() => {
+    try {
+      server.close();
+
+    } catch ( error ) {
+
+      console.error( "agenda api failed to stop: " + error.message );
+    }
+  }
+};
+
+module.exports = api;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.2.0",
   "description": "Agenda",
   "scripts": {
-    "test": "mocha --recursive",
     "lint": "eslint .",
     "dev": "bash scripts/dev.sh",
     "setup": "bash scripts/setup.sh"
@@ -12,7 +11,7 @@
     "type": "git",
     "url": "git+https://github.com/SocexSolutions/agenda-v2.git"
   },
-  "author": "Tom Hudson",
+  "authors": "Architect: Tom Hudson, Engineers: Zach Barns, David Oligney",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/SocexSolutions/agenda-v2/issues"


### PR DESCRIPTION
Integrated the API server into the tests as demonstrated in the `participant` tests. It is still suboptimal as you have to have the mongo container running already. 

Definitely need to work of the sketchiness of running all the containers at once. I am trying to get it so that there is a single `docker-compose` file that runs everything and updates with changes. It works for the API but there is a weird bug with the frontend. I think it has to do with where the file is being run from.

Going to add in _redux_ tonight for the frontend.