### PR TITLE
Dev Shell Script Fix

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,10 @@ services:
   ui:
     build: ./www/
     container_name: ui
+    volumes:
+      - ./www/:/app
+      - /app/node_modules
+      - /app/.next
     ports:
       - 3000:3000
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -7,3 +7,5 @@ npm run dev &
 cd ../api
 
 docker compose up &
+
+wait

--- a/www/Dockerfile
+++ b/www/Dockerfile
@@ -10,4 +10,4 @@ COPY . .
 
 EXPOSE 3000
 
-CMD [ "npm", "run", "start" ]
+CMD [ "npm", "run", "dev" ]

--- a/www/components/Button.js
+++ b/www/components/Button.js
@@ -1,12 +1,10 @@
 import PropTypes from "prop-types";
-import { render } from "react-dom";
 import styles from "../styles/Button.module.css";
 
 import DoubleArrowIcon from "@material-ui/icons/DoubleArrow";
-import CheckBoxOutlinedIcon from "@material-ui/icons/Checkboxoutlined"
+import CheckBoxOutlinedIcon from "@material-ui/icons/CheckBoxOutlined";
 import CancelOutlinedIcon from '@material-ui/icons/CancelOutlined';
 import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
-
 
 const Button = ({ icon, text, size, onClick, varient, stretch }) => {
   Button.propTypes = {

--- a/www/docker-compose.yaml
+++ b/www/docker-compose.yaml
@@ -3,7 +3,14 @@ version: "3.7"
 services:
   
   agenda:
-    build: ./
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: agenda
+    restart: always
+    volumes:
+      - ./:/app
+      - /app/node_modules
+      - /app/.next
     ports:
       - 3000:3000

--- a/www/next.config.js
+++ b/www/next.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  wepackDevMiddleware: config => {
+    config.watchOptions = {
+      poll: 1000,
+      aggregateTimeout: 300,
+    }
+
+    return config;
+  }
+}

--- a/www/package.json
+++ b/www/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "next dev",
     "lint": "eslint ."
   },
   "dependencies": {


### PR DESCRIPTION
The `scripts/dev.sh` script now runs mongo, the api, and the frontend all at once in one terminal. It reads out logs and all services will be canceled with `ctrl+c` in the host terminal.