### PR TITLE
Axios Client

### DIFF
--- a/www/store/client.js
+++ b/www/store/client.js
@@ -1,8 +1,8 @@
-import axios from 'axios';
+import axios from "axios";
 
 const client = axios.create({
-  baseURL: 'localhost:5000',
+  baseURL: "http://localhost:5000",
   timeout: 1000
-})
+});
 
 export default client;

--- a/www/store/features/user/userSlice.js
+++ b/www/store/features/user/userSlice.js
@@ -1,53 +1,52 @@
-import client from '../../client';
-import axios from 'axios';
+import client from "../../client";
 
 const initialState = {
   token: null,
   _id: null,
   username: null,
   email: null
-}
+};
 
 const reducer = ( state = initialState, action ) => {
   switch( action.type ) {
 
-    case 'user/register':
-      return action.payload;
+  case "user/register":
+    return action.payload;
 
-    default:
-      return state;
+  default:
+    return state;
   }
-}
+};
 
 export const userRegister = ( email, username, password ) => {
   return async function registerUser( dispatch, getState ) {
     try {
 
-      const { data } = await axios.post(
-        'http://localhost:5000/user/register',
+      const { data } = await client.post(
+        "/user/register",
         {
           email,
           username,
           password
         }
-      )
+      );
 
-      dispatch( 
-        { 
-          type: 'user/register', 
+      dispatch(
+        {
+          type: "user/register",
           payload: {
             token:    data.token,
             _id:      data.user._id,
             username: data.user.username,
             email:    data.user.email
-          } 
+          }
         }
-      )
+      );
     } catch ( error ) {
 
       console.error( error.message );
     }
-  }
-} 
+  };
+};
 
 export default reducer;


### PR DESCRIPTION
Using a single client will allow us to easily switch between different urls for the api which we will need to do for deployment. Also, for the create meeting page, I might extend this client to have new methods like `authPost` that grabs the **JWT** from the store if there is one and uses it in the `authentication` header of the request.