### PR TITLE
Participant Refactor to Require Email and Meeting ID Only.

### DIFF
--- a/api/lib/controllers/meeting.js
+++ b/api/lib/controllers/meeting.js
@@ -8,9 +8,7 @@ module.exports = {
       const meeting = await Meeting.findById( _id );
 
       res.sendStatus( 200 ).send( meeting );
-
     } catch ( error ) {
-
       res.status( 500 ).send( error.message );
     }
   },
@@ -22,10 +20,8 @@ module.exports = {
       const meeting = await Meeting.create({ owner_id, date });
 
       res.status( 201 ).send( meeting );
-
     } catch ( error ) {
-
       res.status( 500 ).send( error.message );
     }
-  }
+  },
 };

--- a/api/lib/controllers/participant.js
+++ b/api/lib/controllers/participant.js
@@ -2,19 +2,17 @@ const Participant = require( "../models/participant" );
 
 module.exports = {
   create: async( req, res ) => {
-    const { firstName, lastName, email, meeting_id } = req.body;
+    const { email, meeting_id } = req.body;
 
     try {
-      await Participant.create({ firstName, lastName, email, meeting_id });
-
-      res.sendStatus( 201 );
-
-    } catch ( error ) {
-
-      res.status( 500 ).send({
-        success: false,
-        error: error.message
+      const participant = await Participant.create({
+        email,
+        meeting_id,
       });
+
+      res.status( 201 ).send( participant );
+    } catch ( error ) {
+      res.status( 500 ).send( error.message );
     }
-  }
+  },
 };

--- a/api/lib/models/participant.js
+++ b/api/lib/models/participant.js
@@ -1,31 +1,21 @@
 const mongoose = require( "mongoose" );
-const Schema   = mongoose.Schema;
+const Schema = mongoose.Schema;
 
 const participantSchema = new mongoose.Schema(
   {
-    firstName: {
-      type: String,
-      required: true
-    },
-    lastName: {
-      type: String,
-      required: true
-    },
     email: {
       type: String,
-      required: true
+      required: true,
     },
     meeting_id: {
       type: Schema.Types.ObjectId,
       ref: "Meeting",
-      required: true
+      required: true,
     },
   },
   {
-    timestamps: true
+    timestamps: true,
   }
 );
 
-
 module.exports = mongoose.model( "Participant", participantSchema );
-

--- a/api/test/tests/controllers/meeting.js
+++ b/api/test/tests/controllers/meeting.js
@@ -1,34 +1,20 @@
-const assert   = require( "assert" );
-const dbUtils  = require( "../../utils/db" );
-const db       = require( "../../../lib/db" );
-const api      = require( "../../utils/api" );
-const client   = require( "../../utils/client" );
+const assert = require( "assert" );
+const dbUtils = require( "../../utils/db" );
+const db = require( "../../../lib/db" );
+const api = require( "../../utils/api" );
+const client = require( "../../utils/client" );
+const ObjectID = require( "mongoose" ).Types.ObjectId;
+
+const meeting = {
+  owner_id: new ObjectID(),
+  date: "10/10/10",
+  participants: [ "brian@socnet.com", "herman@socnet.com" ],
+};
 
 describe( "controllers/meeting", () => {
-
-  let meeting;
-
   before( async() => {
     await api.start();
     await db.connect();
-
-    const { data } = await client.post(
-      "/user/register",
-      {
-        username: "tom",
-        password: "pass",
-        email:    "thudson@starry.com"
-      }
-    );
-
-    meeting = {
-      owner_id: data.user._id,
-      date: "10/10/10",
-      participants: [
-        "brian@socnet.com",
-        "herman@socnet.com"
-      ]
-    };
   });
 
   beforeEach( async() => {
@@ -41,16 +27,12 @@ describe( "controllers/meeting", () => {
   });
 
   describe( "#create", () => {
-
     const path = "/meeting/create";
 
     it( "should create a meeting with valid inputs", async() => {
       const res = await client.post( path, meeting );
 
-      assert(
-        res.status === 201,
-        "failed to create meeting with valid args"
-      );
+      assert( res.status === 201, "failed to create meeting with valid args" );
 
       assert(
         res.data.date === meeting.date,
@@ -60,15 +42,13 @@ describe( "controllers/meeting", () => {
 
     it( "should not create a meeting without id", async() => {
       const invalidMeeting = { ...meeting, owner_id: "invalid_id" };
-      const errorRegex     = /^Meeting validation failed: owner_id/;
+      const errorRegex = /^Meeting validation failed: owner_id/;
 
       try {
         await client.post( path, invalidMeeting );
 
         throw new Error( "accepted invalid owner_id" );
-
       } catch ( err ) {
-
         assert(
           errorRegex.test( err.response.data ),
           "Error occured for wrong reason: " + err
@@ -78,15 +58,13 @@ describe( "controllers/meeting", () => {
 
     it( "should not create a meeting without date", async() => {
       const invalidMeeting = { ...meeting, date: "" };
-      const errorRegex     = /^Meeting validation failed: date/;
+      const errorRegex = /^Meeting validation failed: date/;
 
       try {
         await client.post( path, invalidMeeting );
 
         throw new Error( "accepted invalid owner_id" );
-
       } catch ( err ) {
-
         assert(
           errorRegex.test( err.response.data ),
           "Error occured for wrong reason: " + err
@@ -96,22 +74,18 @@ describe( "controllers/meeting", () => {
 
     it( "should not create a meeting without date", async() => {
       const invalidMeeting = { ...meeting, date: "" };
-      const errorRegex     = /^Meeting validation failed: date/;
+      const errorRegex = /^Meeting validation failed: date/;
 
       try {
         await client.post( path, invalidMeeting );
 
         throw new Error( "accepted invalid owner_id" );
-
       } catch ( err ) {
-
         assert(
           errorRegex.test( err.response.data ),
           "Error occured for wrong reason: " + err
         );
       }
     });
-
   });
-
 });

--- a/api/test/tests/controllers/participant.js
+++ b/api/test/tests/controllers/participant.js
@@ -1,20 +1,16 @@
-const assert   = require( "assert" );
-const dbUtils  = require( "../../utils/db" );
-const db       = require( "../../../lib/db" );
-const api      = require( "../../utils/api" );
+const assert = require( "assert" );
+const dbUtils = require( "../../utils/db" );
+const db = require( "../../../lib/db" );
+const api = require( "../../utils/api" );
 const ObjectID = require( "mongoose" ).Types.ObjectId;
-const axios    = require( "axios" );
+const client = require( "../../utils/client" );
 
 const participant = {
-  firstName: "linus",
-  lastName: "torvalds",
   email: "lt@linux.com",
-  meeting_id: new ObjectID
+  meeting_id: new ObjectID(),
 };
 
-
 describe( "controllers/participant", () => {
-
   before( async() => {
     await api.start();
     await db.connect();
@@ -30,50 +26,52 @@ describe( "controllers/participant", () => {
   });
 
   describe( "#create", () => {
-    const path = "http://localhost:5000/participant/create";
+    const path = "/participant/create";
 
     it( "should create a participant with valid inputs", async() => {
-      const res = await axios.post( path, participant );
+      const res = await client.post( path, participant );
 
       assert(
         res.status === 201,
         "failed to create participant with valid args"
       );
+
+      assert(
+        res.data.email === participant.email,
+        "created participant with incorrect email"
+      );
     });
 
     it( "should not create a participant without email", async() => {
       const invalidParticipant = { ...participant, email: "" };
+      const errorRegex = /^Participant validation failed: email/;
 
       try {
-        await axios.post( path, invalidParticipant );
+        await client.post( path, invalidParticipant );
 
         throw new Error( "accepted invalid email" );
-
-      } catch ( err ) { }
+      } catch ( err ) {
+        assert(
+          errorRegex.test( err.response.data ),
+          "Error occured for the wrong reason: " + err
+        );
+      }
     });
 
-    it( "should not create a participant without firstname", async() => {
-      const invalidParticipant = { ...participant, firstName: "" };
+    it( "should not create a participant without meeting_id", async() => {
+      const invalidParticipant = { ...participant, meeting_id: "" };
+      const errorRegex = /^Participant validation failed: meeting_id/;
 
       try {
-        await axios.post( path, invalidParticipant );
+        await client.post( path, invalidParticipant );
 
-        throw new Error( "accepted invalid firstname" );
-
-      } catch ( err ) { }
+        throw new Error( "accepted invalid email" );
+      } catch ( err ) {
+        assert(
+          errorRegex.test( err.response.data ),
+          "Error occured for the wrong reason: " + err
+        );
+      }
     });
-
-    it( "should not create a participant without lastname", async() => {
-      const invalidParticipant = { ...participant, lastname: "" };
-
-      try {
-        await axios.post( path, invalidParticipant );
-
-        throw new Error( "accepted empty last name" );
-
-      } catch ( err ) { }
-    });
-
   });
-
 });


### PR DESCRIPTION
Modified the `participant` controllers and model such that they only require `email` and `meeting_id` as well as refactoring the tests to use the Axios `client`.

We don't want to add the participant first name and last name because it will make entering information take longer when creating a meeting with little benefit.