### PR TITLE
Meeting Update Controller and Jobi Logging

### DIFF
--- a/api/lib/controllers/meeting.js
+++ b/api/lib/controllers/meeting.js
@@ -1,13 +1,18 @@
 const Meeting = require( "../models/meeting" );
 const ObjectID = require( "mongoose" ).Types.ObjectId;
+const logger = require( "@starryinternet/jobi" );
 
 module.exports = {
   index: async( req, res ) => {
     try {
       const meetings = await Meeting.find({});
 
+      logger.log( "debug", "Response: " + meetings );
       res.status( 200 ).send( meetings );
+
     } catch ( error ) {
+
+      logger.log( "error", "INDEX FAILED: " + error.message );
       res.status( 500 ).send( error.message );
     }
   },
@@ -40,8 +45,12 @@ module.exports = {
         }
       ] );
 
+      logger.log( "debug", "Found: " + meeting );
       res.status( 200 ).send( meeting );
+
     } catch ( error ) {
+
+      logger.log( "error", error.message );
       res.status( 500 ).send( error.message );
     }
   },
@@ -52,8 +61,35 @@ module.exports = {
     try {
       const meeting = await Meeting.create({ owner_id, date, name });
 
+      logger.log( "debug", "Created: " + meeting );
       res.status( 201 ).send( meeting );
+
     } catch ( error ) {
+
+      logger.log( "error", "Create Failed: " + error.message );
+      res.status( 500 ).send( error.message );
+    }
+  },
+
+  update: async( req, res ) => {
+    const { _id } = req.params;
+
+    try {
+      const meeting = await Meeting.findOneAndUpdate(
+        { _id },
+        req.body,
+        {
+          new: true, // specify to return updated doc instead of original
+          useFindAndModify: false
+        }
+      );
+
+      logger.log( "debug", "Updated: " + meeting );
+      res.status( 200 ).send( meeting );
+
+    } catch ( error ) {
+
+      logger.log( "error", "Update Failed: " + error.message );
       res.status( 500 ).send( error.message );
     }
   },

--- a/api/lib/routes/meeting.js
+++ b/api/lib/routes/meeting.js
@@ -7,4 +7,6 @@ router.get( "/:_id", meetingController.display );
 
 router.post( "/", meetingController.create );
 
+router.patch( "/:_id", meetingController.update );
+
 module.exports = router;

--- a/api/package.json
+++ b/api/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/SocexSolutions/agenda-api#readme",
   "dependencies": {
+    "@starryinternet/jobi": "^1.1.0",
     "axios": "^0.21.1",
     "cors": "^2.8.5",
     "express": "4.17.1",

--- a/api/test/tests/controllers/meeting.js
+++ b/api/test/tests/controllers/meeting.js
@@ -5,13 +5,13 @@ const api = require( "../../utils/api" );
 const client = require( "../../utils/client" );
 const ObjectID = require( "mongoose" ).Types.ObjectId;
 
-const meeting = {
+const MEETING = {
   name: "Meeting 1",
   owner_id: new ObjectID(),
   date: "10/10/10"
 };
 
-const meeting2 = {
+const MEETING_2 = {
   name: "Meeting 2",
   owner_id: new ObjectID(),
   date: "10/12/10"
@@ -35,10 +35,10 @@ describe( "controllers/meeting", () => {
 
   describe( "#index", () => {
     it( "should fetch all meetings", async() => {
-      const meetingRes = await client.post( "meeting/", meeting );
-      const meetingRes2 = await client.post( "meeting/", meeting2 );
+      const meetingRes = await client.post( "meeting/", MEETING );
+      const meetingRes2 = await client.post( "meeting/", MEETING_2 );
 
-      const meetings = await client.get( "meeting/", meeting );
+      const meetings = await client.get( "meeting/", MEETING );
 
       assert.deepEqual( meetings.data, [ meetingRes.data, meetingRes2.data ] );
     });
@@ -46,7 +46,7 @@ describe( "controllers/meeting", () => {
 
   describe( "#display", () => {
     it( "should fetch meeting with participants", async() => {
-      const meetingRes = await client.post( "meeting/", meeting );
+      const meetingRes = await client.post( "meeting/", MEETING );
 
       const participant = {
         email: "email@email.com",
@@ -67,7 +67,7 @@ describe( "controllers/meeting", () => {
     });
 
     it( "should fetch meeting with topics", async() => {
-      const meetingRes = await client.post( "meeting/", meeting );
+      const meetingRes = await client.post( "meeting/", MEETING );
 
       const topic = {
         name: "Jazz",
@@ -92,18 +92,18 @@ describe( "controllers/meeting", () => {
     const path = "/meeting/";
 
     it( "should create a meeting with valid inputs", async() => {
-      const res = await client.post( path, meeting );
+      const res = await client.post( path, MEETING );
 
       assert( res.status === 201, "failed to create meeting with valid args" );
 
       assert(
-        res.data.date === meeting.date,
+        res.data.date === MEETING.date,
         "created meeting with incorrect date: " + res.data.date
       );
     });
 
     it( "should not create a meeting without id", async() => {
-      const invalidMeeting = { ...meeting, owner_id: "invalid_id" };
+      const invalidMeeting = { ...MEETING, owner_id: "invalid_id" };
       const errorRegex = /^Meeting validation failed: owner_id/;
 
       try {
@@ -119,7 +119,7 @@ describe( "controllers/meeting", () => {
     });
 
     it( "should not create a meeting without date", async() => {
-      const invalidMeeting = { ...meeting, date: "" };
+      const invalidMeeting = { ...MEETING, date: "" };
       const errorRegex = /^Meeting validation failed: date/;
 
       try {
@@ -135,7 +135,7 @@ describe( "controllers/meeting", () => {
     });
 
     it( "should not create a meeting without date", async() => {
-      const invalidMeeting = { ...meeting, date: "" };
+      const invalidMeeting = { ...MEETING, date: "" };
       const errorRegex = /^Meeting validation failed: date/;
 
       try {
@@ -148,6 +148,38 @@ describe( "controllers/meeting", () => {
           "Error occurred for wrong reason: " + err
         );
       }
+    });
+  });
+
+  describe( "#update", async() => {
+    const path = "/meeting/";
+
+    it( "should update all meeting attributes", async() => {
+      const createRes = await client.post( path, MEETING );
+
+      const updateRes = await client.patch(
+        path + createRes.data._id,
+        MEETING_2
+      );
+
+      assert.equal( updateRes.data.name, MEETING_2.name );
+      assert.equal( updateRes.data.date, MEETING_2.date );
+      assert.equal( updateRes.data.owner_id, MEETING_2.owner_id.toString() );
+      assert.equal( createRes.data._id, updateRes.data._id );
+    });
+
+    it( "should update some meeting attributes", async() => {
+      const createRes = await client.post( path, MEETING );
+
+      const update = { name: "First Geneva Convention" };
+
+      const updateRes = await client.patch(
+        path + createRes.data._id,
+        update
+      );
+
+      assert.equal( updateRes.data.name, update.name );
+      assert.equal( updateRes.data.date, createRes.data.date  );
     });
   });
 });


### PR DESCRIPTION
### Summary
This pr adds a controller for updating meeting docs. It does not include what we will need in order to update participants and topics for a meeting. It also adds in [@starryinternet/jobi](https://www.npmjs.com/package/@starryinternet/jobihttps://www.npmjs.com/package/@starryinternet/jobi) a custom logging utility. This allows for better logging by using different logging levels. For example, we can have verbose logs what we use for debugging like this:
```js
const logger = require("@starryinternet/jobi");

logger.log( "info", "Some Message" );
```
This log will only show up when you set the `NODE_DEBUG=trace` variable when running the api. The reason we don't just go for `console.log` everywhere is that this would lead to an inordinate amount of logs in production making them difficult to parse. Additionally, logs can be used to reveal security vulnerabilities.

### Key Takeaways
- We can and should use `Jobi` to put more logs in the apis (and potentially frontend) to make debugging easier.
- The meeting update controller is ready to go.

