### PR TITLE
Added pull request template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+### Context
+<!--
+Links should include the following:
+  - Ticket
+  - Related PRs
+  - Blocks/Is Blocked by Ticket
+Prose should answer the following:
+  - Who uses this and for what?
+  - Is this part of a greater feature? What is it?
+-->
+
+### Implementation
+<!--
+Prose should answer the following:
+  - What major changes have been made and why?
+  - Are there any breaking changes? Do you see any paths to mitigation?
+-->
+
+<!--
+### Feedback Request (optional)
+Prose should include:
+  - Are there any parts of the implementation you are unsure about?
+  - Any obfuscated code?
+
+You can also a add a comment directly to the pr.
+-->
+
+<!--
+### Preview (optional)
+Screen captures of changes if on frontend.
+-->
+
+### Merge Checklist
+- [ ] Correct Target Branch
+- [ ] Pre-Review Diff Check
+- [ ] PR Description
+- [ ] Add Reviewers and Assignees
+- [ ] Review Complete
+- [ ] Rebase
+- [ ] Rebase Approved


### PR DESCRIPTION
### Context
To make PR descriptions easier to think about its pretty common to have some sort of template, here is ours.

### Implementation
All that is required to add PR templates is to place a file titled `pull_request_template` in the `.github` directory of a project, hence, we have a template.