### PR TITLE
Add authentication to restricted routes in api.

### DIFF
--- a/api/lib/controllers/user.js
+++ b/api/lib/controllers/user.js
@@ -1,12 +1,12 @@
-const User      = require( "../models/user" );
-const PassUtils = require( "../utils/password" );
-const JWTUtils  = require( "../utils/jwt" );
-const logger    = require( "@starryinternet/jobi" );
+const User      = require('../models/user');
+const PassUtils = require('../utils/password');
+const JWTUtils  = require('../utils/jwt');
+const logger    = require('@starryinternet/jobi');
 
 
 module.exports = {
   async register( req, res ) {
-    logger.info( "registering user" );
+    logger.info('registering user');
 
     try {
       // unpack from request by variable names in form
@@ -17,14 +17,14 @@ module.exports = {
 
       if ( existingUser ) {
         return res.status( 403 ).send(
-          new Error( "username already exists" )
+          new Error('username already exists')
         );
       }
 
       // password is not stored in db and is thus not validated by the model so
       // we quality check it here.
       if ( !password ) {
-        throw new Error( "Invalid Password" );
+        throw new Error('Invalid Password');
       }
 
       const { hash, salt } = PassUtils.genPassword( password );
@@ -51,7 +51,7 @@ module.exports = {
         expiresIn
       });
 
-      logger.info( "user registered" );
+      logger.info('user registered');
 
     } catch ( err ) {
 
@@ -61,7 +61,7 @@ module.exports = {
 
   async login( req, res ) {
 
-    logger.info( "logging in user" );
+    logger.info('logging in user');
 
     try {
       // unpack from request
@@ -76,7 +76,7 @@ module.exports = {
         return (
           res.status( 401 ).json({
             success: false,
-            msg: "invalid username" // need to change for prod
+            msg: 'invalid username' // need to change for prod
           })
         );
       }
@@ -103,12 +103,12 @@ module.exports = {
           expiresIn
         });
 
-        logger.info( "logged in user" );
+        logger.info('logged in user');
 
       } else {
         res.status( 401 ).json({
           success: false,
-          msg: "invalid credentials"
+          msg: 'invalid credentials'
         });
       }
 
@@ -121,11 +121,11 @@ module.exports = {
   },
 
   async refresh( req, res ) {
-    logger.info( "refreshing token" );
+    logger.info('refreshing token');
 
     try {
       logger.info(
-        "authorization: " + JSON.stringify( req.headers.authorization )
+        'authorization: ' + JSON.stringify( req.headers.authorization )
       );
 
       const token = req.headers.authorization;
@@ -143,11 +143,11 @@ module.exports = {
         }
       });
 
-      logger.info( "refreshed token" );
+      logger.info('refreshed token');
 
     } catch ( err ) {
 
       logger.error( err.message );
     }
-  },
+  }
 };

--- a/api/lib/middleware/authenticate.js
+++ b/api/lib/middleware/authenticate.js
@@ -1,32 +1,35 @@
-const jsonwebtoken = require( "jsonwebtoken" );
-const fs           = require( "fs" );
-const path         = require( "path" );
+const jsonwebtoken = require('jsonwebtoken');
+const fs           = require('fs');
+const path         = require('path');
+const jobi         = require('@starryinternet/jobi');
 
-const pathToKey = path.join( __dirname, "../../keys/id_rsa_pub.pem" );
-const PUB_KEY   = fs.readFileSync( pathToKey, "utf8" );
+const pathToKey = path.join( __dirname, '../../keys/id_rsa_pub.pem' );
+const PUB_KEY   = fs.readFileSync( pathToKey, 'utf8' );
 
 const authenticate = ( req, res, next ) => {
-  try {
-    const [ bearer, token ] = req.headers.authorization.split( " " );
+  jobi.trace('authenticating');
 
-    if ( !bearer === "Bearer" || !token.match( /\S*\.\S*\.\S*/ ) ) {
-      res.status( 401 ).json({ success: false, msg: "Forbidden" });
+  try {
+    const [ bearer, token ] = req.headers.authorization.split(' ');
+
+    if ( !bearer === 'Bearer' || !token.match( /\S*\.\S*\.\S*/ ) ) {
+      return res.status( 401 ).json({ success: false, msg: 'Forbidden' });
     }
 
     req.jwt = jsonwebtoken.verify(
       token,
       PUB_KEY,
       {
-        algorithms: [ "RS256" ]
+        algorithms: [ 'RS256' ]
       }
     );
 
     next();
 
-  } catch( err ) {
-    console.error( err );
+  } catch ( err ) {
+    jobi.error( err );
 
-    res.status( 401 ).json({ success: false, msg: "Forbidden" });
+    res.status( 401 ).json({ success: false, msg: 'Forbidden' });
   }
 };
 

--- a/api/lib/routes/index.js
+++ b/api/lib/routes/index.js
@@ -1,15 +1,16 @@
-const router      = require( "express" ).Router();
+const router = require('express').Router();
+const auth   = require('../middleware/authenticate');
 
-const health      = require( "./health" );
-const user        = require( "./user" );
-const meeting     = require( "./meeting" );
-const topic       = require( "./topic" );
-const participant = require( "./participant" );
+const health      = require('./health');
+const user        = require('./user');
+const meeting     = require('./meeting');
+const topic       = require('./topic');
+const participant = require('./participant');
 
-router.use( "/health", health );
-router.use( "/user", user );
-router.use( "/meeting", meeting );
-router.use( "/topic", topic );
-router.use( "/participant", participant );
+router.use( '/health', health );
+router.use( '/user', user );
+router.use( '/meeting', auth, meeting );
+router.use( '/topic', auth, topic );
+router.use( '/participant', auth, participant );
 
 module.exports = router;

--- a/api/lib/routes/meeting.js
+++ b/api/lib/routes/meeting.js
@@ -1,9 +1,10 @@
-const router            = require( "express" ).Router();
-const meetingController = require( "../controllers/meeting" );
+const router            = require('express').Router();
+const meetingController = require('../controllers/meeting');
 
-router.get( "/", meetingController.index );
-router.get( "/:_id", meetingController.display );
-router.post( "/", meetingController.create );
-router.put( "/", meetingController.update );
+
+router.get( '/', meetingController.index );
+router.get( '/:_id', meetingController.display );
+router.post( '/', meetingController.create );
+router.put( '/', meetingController.update );
 
 module.exports = router;


### PR DESCRIPTION
### Context
Added authentication to restricted routes (for now those other then `/user`).

### Implementation
In each of the routes that we do not want to allow users to access without logging in, the `authenticate()` middleware function was added. This function parses and verifies the JWT in a requests `authorization` header. Our frontend requests will need to include an authorization header going forward.

### Merge Checklist
- [x] Correct Target Branch
- [x] Pre-Review Diff Check
- [x] PR Description
- [x] Add Reviewers and Assignees
- [ ] Review Complete
- [ ] Rebase
- [ ] Rebase Approved
