### PR TITLE
Added 'Authorization' header to test client.

### DIFF
--- a/api/lib/controllers/user.js
+++ b/api/lib/controllers/user.js
@@ -7,10 +7,10 @@ const logger    = require('@starryinternet/jobi');
 module.exports = {
   async register( req, res ) {
     logger.info('registering user');
+    logger.info( req.body );
 
     try {
       // unpack from request by variable names in form
-      logger.info( req.body );
       const { email, username, password } = req.body;
 
       const existingUser = await User.findOne({ username });

--- a/api/lib/db/index.js
+++ b/api/lib/db/index.js
@@ -20,8 +20,7 @@ db.connect = async() => {
 
     await mongoose.connect( dbConStr, {
       useNewUrlParser: true,
-      useUnifiedTopology: true,
-      useCreateIndex: true
+      useUnifiedTopology: true
     });
 
     jobi.info('database connected');

--- a/api/test/tests/controllers/meeting.js
+++ b/api/test/tests/controllers/meeting.js
@@ -1,39 +1,48 @@
-const chai        = require( "chai" );
-const chaiSubset  = require( "chai-subset" );
-const dbUtils     = require( "../../utils/db" );
-const db          = require( "../../../lib/db" );
-const api         = require( "../../utils/api" );
-const client      = require( "../../utils/client" );
-const ObjectID    = require( "mongoose" ).Types.ObjectId;
-const Meeting     = require( "../../../lib/models/meeting" );
-const Participant = require( "../../../lib/models/participant" );
-const Topic       = require( "../../../lib/models/topic" );
+const chai        = require('chai');
+const chaiSubset  = require('chai-subset');
+const dbUtils     = require('../../utils/db');
+const db          = require('../../../lib/db');
+const api         = require('../../utils/api');
+const client      = require('../../utils/client');
+const ObjectID    = require('mongoose').Types.ObjectId;
+const Meeting     = require('../../../lib/models/meeting');
+const Participant = require('../../../lib/models/participant');
+const Topic       = require('../../../lib/models/topic');
 
 chai.use( chaiSubset );
 
 const assert = chai.assert;
 
-
 const fakeMeeting = {
-  name:     "Meeting 1",
+  name:     'Meeting 1',
   owner_id: new ObjectID().toString(),
-  date:     "10/10/10"
+  date:     '10/10/10'
 };
 
 const fakeParticipant = {
-  email: "thudson@thudson.thud"
+  email: 'thudson@thudson.thud'
 };
 
 const fakeTopic = {
-  name:  "Topic 1",
+  name:  'Topic 1',
   likes: [ ]
 };
 
-describe( "controllers/meeting", () => {
+describe( 'controllers/meeting', () => {
 
   before( async() => {
     await api.start();
     await db.connect();
+
+    const res = await client.post(
+      '/user/register',
+      { username: 'user', password: 'pass', email: 'email' }
+    );
+
+    client.defaults.headers.common['Authorization'] = res.data.token;
+  });
+
+  beforeEach( async() => {
     await dbUtils.clean();
   });
 
@@ -42,34 +51,30 @@ describe( "controllers/meeting", () => {
     await db.disconnect();
   });
 
-  afterEach( async() => {
-    await dbUtils.clean();
-  });
+  describe( '#index', () => {
 
-  describe( "#index", () => {
-
-    it( "should fetch all meetings", async() => {
+    it( 'should fetch all meetings', async() => {
       Meeting.create( fakeMeeting );
       Meeting.create( fakeMeeting );
 
-      const meetings = await client.get( "/meeting" );
+      const meetings = await client.get('/meeting');
 
       assert.containSubset(
-        meetings.data[0],
+        meetings.data[ 0 ],
         fakeMeeting
       );
 
       assert.containSubset(
-        meetings.data[1],
+        meetings.data[ 1 ],
         fakeMeeting
       );
     });
 
   });
 
-  describe( "#display", () => {
+  describe( '#display', () => {
 
-    it( "should fetch meeting with participants and topics", async() => {
+    it( 'should fetch meeting with participants and topics', async() => {
       const { _id } = await Meeting.create( fakeMeeting );
 
       await Participant.create({
@@ -82,29 +87,29 @@ describe( "controllers/meeting", () => {
         meeting_id: _id
       });
 
-      const res = await client.get( `/meeting/${_id}` );
+      const res = await client.get( `/meeting/${ _id }` );
 
       assert.containSubset(
-        res.data[0],
+        res.data[ 0 ],
         fakeMeeting
       );
 
       assert.containSubset(
-        res.data[0].participants[0],
+        res.data[ 0 ].participants[ 0 ],
         fakeParticipant
       );
 
       assert.containSubset(
-        res.data[0].topics[0],
+        res.data[ 0 ].topics[ 0 ],
         fakeTopic
       );
     });
 
   });
 
-  describe( "#create", () => {
+  describe( '#create', () => {
 
-    it( "should create meeting with participants and topics", async() => {
+    it( 'should create meeting with participants and topics', async() => {
       const meeting = {
         meeting: fakeMeeting,
         participants: [ fakeParticipant ],
@@ -112,7 +117,7 @@ describe( "controllers/meeting", () => {
       };
 
       const { data } = await client.post(
-        "/meeting",
+        '/meeting',
         meeting
       );
 
@@ -122,12 +127,12 @@ describe( "controllers/meeting", () => {
       );
 
       assert.containSubset(
-        data.topics[0],
+        data.topics[ 0 ],
         fakeTopic
       );
 
       assert.containSubset(
-        data.participants[0],
+        data.participants[ 0 ],
         fakeParticipant
       );
 
@@ -135,9 +140,9 @@ describe( "controllers/meeting", () => {
 
   });
 
-  describe( "#update", () => {
+  describe( '#update', () => {
 
-    it( "should update a meetings participants and topics", async() => {
+    it( 'should update a meetings participants and topics', async() => {
       const { _id } = await Meeting.create( fakeMeeting );
 
       await Participant.create({
@@ -153,13 +158,13 @@ describe( "controllers/meeting", () => {
       const meetingUpdate = {
         _id: _id.toString(),
         owner_id: fakeMeeting.owner_id,
-        name: "meeting 2",
-        date: "10/10/12",
+        name: 'meeting 2',
+        date: '10/10/12'
       };
 
       const topicsUpdate = [
         {
-          name: "Topic 3",
+          name: 'Topic 3',
           likes: [
             new ObjectID().toString()
           ]
@@ -168,7 +173,7 @@ describe( "controllers/meeting", () => {
 
       const participantsUpdate = [
         {
-          email: "thudson@thudson.com"
+          email: 'thudson@thudson.com'
         }
       ];
 
@@ -179,7 +184,7 @@ describe( "controllers/meeting", () => {
       };
 
       const { data } = await client.put(
-        "/meeting",
+        '/meeting',
         payload
       );
 
@@ -189,13 +194,13 @@ describe( "controllers/meeting", () => {
       );
 
       assert.containSubset(
-        data.topics[0],
-        topicsUpdate[0]
+        data.topics[ 0 ],
+        topicsUpdate[ 0 ]
       );
 
       assert.containSubset(
-        data.participants[0],
-        participantsUpdate[0]
+        data.participants[ 0 ],
+        participantsUpdate[ 0 ]
       );
     });
 

--- a/api/test/tests/controllers/participant.js
+++ b/api/test/tests/controllers/participant.js
@@ -1,23 +1,29 @@
-const assert   = require( "assert" );
-const dbUtils  = require( "../../utils/db" );
-const db       = require( "../../../lib/db" );
-const api      = require( "../../utils/api" );
-const ObjectID = require( "mongoose" ).Types.ObjectId;
-const client   = require( "../../utils/client" );
+const assert   = require('assert');
+const dbUtils  = require('../../utils/db');
+const db       = require('../../../lib/db');
+const api      = require('../../utils/api');
+const ObjectID = require('mongoose').Types.ObjectId;
+const client   = require('../../utils/client');
 
 const participant = {
-  email: "lt@linux.com",
-  meeting_id: new ObjectID(),
+  email: 'lt@linux.com',
+  meeting_id: new ObjectID()
 };
 
-describe( "controllers/participant", () => {
+describe( 'controllers/participant', () => {
   before( async() => {
     await api.start();
     await db.connect();
-    await dbUtils.clean();
+
+    const res = await client.post(
+      '/user/register',
+      { username: 'user', password: 'pass', email: 'email' }
+    );
+
+    client.defaults.headers.common['Authorization'] = res.data.token;
   });
 
-  afterEach( async() => {
+  beforeEach( async() => {
     await dbUtils.clean();
   });
 
@@ -26,31 +32,31 @@ describe( "controllers/participant", () => {
     await db.disconnect();
   });
 
-  describe( "#create", () => {
-    const path = "/participant";
+  describe( '#create', () => {
+    const path = '/participant';
 
-    it( "should create a participant with valid inputs", async() => {
+    it( 'should create a participant with valid inputs', async() => {
       const res = await client.post( path, participant );
 
       assert(
         res.status === 201,
-        "failed to create participant with valid args"
+        'failed to create participant with valid args'
       );
 
       assert(
         res.data.email === participant.email,
-        "created participant with incorrect email"
+        'created participant with incorrect email'
       );
     });
 
-    it( "should not create a participant without email", async() => {
-      const invalidParticipant = { ...participant, email: "" };
+    it( 'should not create a participant without email', async() => {
+      const invalidParticipant = { ...participant, email: '' };
       const errorRegex = /^Participant validation failed: email/;
 
       try {
         await client.post( path, invalidParticipant );
 
-        throw new Error( "accepted invalid email" );
+        throw new Error('accepted invalid email');
       } catch ( err ) {
         assert(
           errorRegex.test( err.response.data.message ),
@@ -59,14 +65,14 @@ describe( "controllers/participant", () => {
       }
     });
 
-    it( "should not create a participant without meeting_id", async() => {
-      const invalidParticipant = { ...participant, meeting_id: "" };
+    it( 'should not create a participant without meeting_id', async() => {
+      const invalidParticipant = { ...participant, meeting_id: '' };
       const errorRegex = /^Participant validation failed: meeting_id/;
 
       try {
         await client.post( path, invalidParticipant );
 
-        throw new Error( "accepted invalid email" );
+        throw new Error('accepted invalid email');
       } catch ( err ) {
         assert(
           errorRegex.test( err.response.data.message ),

--- a/api/test/tests/controllers/topic.js
+++ b/api/test/tests/controllers/topic.js
@@ -1,21 +1,28 @@
-const assert   = require( "assert" );
-const dbUtils  = require( "../../utils/db" );
-const db       = require( "../../../lib/db" );
-const api      = require( "../../utils/api" );
-const client   = require( "../../utils/client" );
-const ObjectID = require( "mongoose" ).Types.ObjectId;
+const assert   = require('assert');
+const dbUtils  = require('../../utils/db');
+const db       = require('../../../lib/db');
+const api      = require('../../utils/api');
+const client   = require('../../utils/client');
+const ObjectID = require('mongoose').Types.ObjectId;
 
 const topic = {
-  name: "topic name",
+  name: 'topic name',
   meeting_id: new ObjectID(),
-  likes: [ new ObjectID(), new ObjectID() ],
+  likes: [ new ObjectID(), new ObjectID() ]
 };
 
-describe( "api/lib/controllers/topic", () => {
+describe( 'api/lib/controllers/topic', () => {
 
   before( async() => {
     await api.start();
     await db.connect();
+
+    const res = await client.post(
+      '/user/register',
+      { username: 'user', password: 'pass', email: 'email' }
+    );
+
+    client.defaults.headers.common['Authorization'] = res.data.token;
   });
 
   beforeEach( async() => {
@@ -24,65 +31,64 @@ describe( "api/lib/controllers/topic", () => {
 
   after( async() => {
     await api.stop();
-    await dbUtils.clean();
     await db.disconnect();
   });
 
-  describe( "#create", () => {
-    const path = "/topic";
+  describe( '#create', () => {
+    const path = '/topic';
 
-    it( "should create topic with valid inputs", async() => {
+    it( 'should create topic with valid inputs', async() => {
       const res = await client.post( path, topic );
 
-      assert( res.status === 201, "failed to create topic with valid inputs" );
+      assert( res.status === 201, 'failed to create topic with valid inputs' );
 
       assert(
         res.data.name === topic.name,
-        "created topic with incorrect name: " + res.data.name
+        'created topic with incorrect name: ' + res.data.name
       );
     });
 
-    it( "should create topic without likes", async() => {
+    it( 'should create topic without likes', async() => {
       const topicWithoutParticipants = { ...topic, likes: [] };
 
       const res = await client.post( path, topicWithoutParticipants );
 
-      assert( res.status === 201, "failed to create topic without likes" );
+      assert( res.status === 201, 'failed to create topic without likes' );
 
       assert(
         res.data.likes.length === 0,
-        "created topic with incorrect likes: " + res.data.likes
+        'created topic with incorrect likes: ' + res.data.likes
       );
     });
 
-    it( "should not create topic without name", async() => {
-      const topicWithoutName = { ...topic, name: "" };
+    it( 'should not create topic without name', async() => {
+      const topicWithoutName = { ...topic, name: '' };
       const errorRegex = /^Topic validation failed: name/;
 
       try {
         await client.post( path, topicWithoutName );
 
-        throw new Error( "accepted topic without name" );
+        throw new Error('accepted topic without name');
       } catch ( err ) {
         assert(
           errorRegex.test( err.response.data ),
-          "failed to create topic for wrong reason: " + err.response.data
+          'failed to create topic for wrong reason: ' + err.response.data
         );
       }
     });
 
-    it( "should not create topic without meeting_id", async() => {
-      const topicWithoutMeetingId = { ...topic, meeting_id: "" };
+    it( 'should not create topic without meeting_id', async() => {
+      const topicWithoutMeetingId = { ...topic, meeting_id: '' };
       const errorRegex = /^Topic validation failed: meeting_id/;
 
       try {
         await client.post( path, topicWithoutMeetingId );
 
-        throw new Error( "accepted topic without meeting_id" );
+        throw new Error('accepted topic without meeting_id');
       } catch ( err ) {
         assert(
           errorRegex.test( err.response.data ),
-          "failed to create topic for wrong reason: " + err.response.data
+          'failed to create topic for wrong reason: ' + err.response.data
         );
       }
     });

--- a/api/test/tests/controllers/user.js
+++ b/api/test/tests/controllers/user.js
@@ -1,16 +1,16 @@
-const assert  = require( "assert" );
-const dbUtils = require( "../../utils/db" );
-const db      = require( "../../../lib/db" );
-const api     = require( "../../utils/api" );
-const client  = require( "../../utils/client" );
+const assert  = require('assert');
+const dbUtils = require('../../utils/db');
+const db      = require('../../../lib/db');
+const api     = require('../../utils/api');
+const client  = require('../../utils/client');
 
 const user = {
-  username: "thudson",
-  password: "thudson",
-  email:    "email"
+  username: 'thudson',
+  password: 'thudson',
+  email:    'email'
 };
 
-describe( "api/lib/controllers/user.js", () => {
+describe( 'api/lib/controllers/user.js', () => {
 
   before( async() => {
     await api.start();
@@ -23,28 +23,27 @@ describe( "api/lib/controllers/user.js", () => {
 
   after( async() => {
     await api.stop();
-    await dbUtils.clean();
     await db.disconnect();
   });
 
-  describe( "#register", () => {
+  describe( '#register', () => {
 
-    const path = "/user/register";
+    const path = '/user/register';
 
-    it( "should register successfully when given valid creds", async() => {
+    it( 'should register successfully when given valid creds', async() => {
       const res = await client.post( path, user );
 
       assert( res.status === 201 );
     });
 
-    it( "should register return user info", async() => {
+    it( 'should register return user info', async() => {
       const res = await client.post( path, user );
 
-      assert.strictEqual( res.data.user.email, "email" );
-      assert.strictEqual( res.data.user.username, "thudson" );
+      assert.strictEqual( res.data.user.email, 'email' );
+      assert.strictEqual( res.data.user.username, 'thudson' );
     });
 
-    it( "should not register a user with an existing username", async() => {
+    it( 'should not register a user with an existing username', async() => {
       await client.post( path, user );
 
       try {
@@ -55,7 +54,7 @@ describe( "api/lib/controllers/user.js", () => {
       }
     });
 
-    it( "should register return an auth token", async() => {
+    it( 'should register return an auth token', async() => {
       const res = await client.post( path, user );
 
       // eslint-disable-next-line
@@ -64,10 +63,10 @@ describe( "api/lib/controllers/user.js", () => {
       assert( tokenRegex.test( res.data.token ) );
     });
 
-    it( "should not register user with invalid email", async() => {
+    it( 'should not register user with invalid email', async() => {
       const invalidUser = {
         ...user,
-        email: ""
+        email: ''
       };
 
       let acceptedInvalidEmail = false;
@@ -80,10 +79,10 @@ describe( "api/lib/controllers/user.js", () => {
       assert( !acceptedInvalidEmail );
     });
 
-    it( "should not register user with invalid username", async() => {
+    it( 'should not register user with invalid username', async() => {
       const invalidUser = {
         ...user,
-        username: ""
+        username: ''
       };
 
       let acceptedInvalidUsername = false;
@@ -96,10 +95,10 @@ describe( "api/lib/controllers/user.js", () => {
       assert( !acceptedInvalidUsername );
     });
 
-    it( "should not register user with invalid password", async() => {
+    it( 'should not register user with invalid password', async() => {
       const invalidUser = {
         ...user,
-        password: ""
+        password: ''
       };
 
       let acceptedInvalidPassword = false;
@@ -114,9 +113,9 @@ describe( "api/lib/controllers/user.js", () => {
 
   });
 
-  describe( "#login", () => {
+  describe( '#login', () => {
 
-    const path = "/user/login";
+    const path = '/user/login';
 
     const loginCreds = {
       username: user.username,
@@ -125,21 +124,21 @@ describe( "api/lib/controllers/user.js", () => {
 
     beforeEach( async() => {
       await client.post(
-        "/user/register",
+        '/user/register',
         user
       );
     });
 
-    it( "should login successfully when given valid creds", async() => {
+    it( 'should login successfully when given valid creds', async() => {
       const res = await client.post( path, loginCreds );
 
       assert( res.status === 200 );
     });
 
-    it( "should not login user with invalid password", async() => {
+    it( 'should not login user with invalid password', async() => {
       const invalidUser = {
         ...loginCreds,
-        password: "bacon"
+        password: 'bacon'
       };
 
       let acceptedInvalidPassword = false;
@@ -152,13 +151,13 @@ describe( "api/lib/controllers/user.js", () => {
       assert( !acceptedInvalidPassword );
     });
 
-    it( "should not login user with invalid username", async() => {
+    it( 'should not login user with invalid username', async() => {
       const invalidUser = {
         ...loginCreds,
-        username: "bacon"
+        username: 'bacon'
       };
 
-      let acceptedInvalidUsername = false;
+      const acceptedInvalidUsername = false;
 
       try {
         await client.post( path, invalidUser );

--- a/api/test/utils/client.js
+++ b/api/test/utils/client.js
@@ -1,8 +1,8 @@
-const axios = require( "axios" );
+const axios = require('axios');
 
 const client = axios.create({
-  baseURL: "http://localhost:4000",
-  timeout: 1000,
+  baseURL: 'http://localhost:4000',
+  timeout: 1000
 });
 
 module.exports = client;

--- a/api/test/utils/db.js
+++ b/api/test/utils/db.js
@@ -1,4 +1,4 @@
-const mongoose = require( "mongoose" );
+const mongoose = require('mongoose');
 
 /**
  * Utils for testing regarding the database like clearing all data.
@@ -14,12 +14,12 @@ const utils = {
     const collections = await mongoose.connection.db.collections();
     const promises = [];
 
-    for ( let collection of collections ) {
+    for ( const collection of collections ) {
       promises.push( collection.deleteMany({}) );
     }
 
     return Promise.all( promises );
-  },
+  }
 };
 
 module.exports = utils;


### PR DESCRIPTION
### Context
Since we added the authentication middleware to our meetings, participants, and topics [here](https://github.com/SocexSolutions/agenda-v2/blob/master/api/lib/routes/index.js#L12-L14), we need to add the `Authorization` header to each request that has an auth token as a value so that it can be verified [here](https://github.com/SocexSolutions/agenda-v2/blob/master/api/lib/middleware/authenticate.js#L13-L25).

### Implementation
In order to add a `Authorization` header with a token, we first need to get a token. We get a token by making a request to `user/register` with a `username`, `email`, and `password` in its payload. Then in the `before` block of the tests, we add tell `axios` to use the token as the `Authorization` header. So we end up with this before our tests:

```js
  before( async() => {
    await api.start();
    await db.connect();

    const res = await client.post(
      '/user/register',
      { username: 'user', password: 'pass', email: 'email' }
    );

    client.defaults.headers.common['Authorization'] = res.data.token;
  });
```

### Merge Checklist
- [x] Correct Target Branch
- [x] Pre-Review Diff Check
- [x] PR Description
- [x] Add Reviewers and Assignees
- [ ] Review Complete
- [ ] Rebase
- [ ] Rebase Approved
