### PR TITLE
Remove props in mongoose constructor.

### DIFF
--- a/api/lib/db/index.js
+++ b/api/lib/db/index.js
@@ -18,11 +18,7 @@ db.connect = async() => {
 
     jobi.info( 'using dbConStr ' + dbConStr );
 
-    await mongoose.connect( dbConStr, {
-      useNewUrlParser: true,
-      useUnifiedTopology: true,
-      useCreateIndex: true
-    });
+    await mongoose.connect( dbConStr );
 
     jobi.info('database connected');
 


### PR DESCRIPTION
### Context
Since we upgraded `mongoose` to version 6,  most of the common connection props are now defaults meaning we no longer need to include them according to the migration docs [here](https://mongoosejs.com/docs/migrating_to_6.html#no-more-deprecation-warning-options) so we are dropping them.

### Implementation
Removed unnecessary connection constructor props.

### Merge Checklist
- [ ] Correct Target Branch
- [ ] Pre-Review Diff Check
- [ ] PR Description
- [ ] Add Reviewers and Assignees
- [ ] Review Complete
- [ ] Rebase
- [ ] Rebase Approved
