### PR TITLE
add nyc for code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 
 # testing
 */coverage
+.nyc_output
 
 # next.
 .next

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "lint": "eslint .",
     "dev": "bash scripts/dev.sh",
     "setup": "bash scripts/setup.sh",
-    "test": "bash scripts/test.sh"
+    "test": "bash scripts/test.sh",
+    "coverage": "nyc npm run test"
   },
   "repository": {
     "type": "git",
@@ -29,7 +30,8 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "faker": "^5.5.3",
     "mocha": "^9.1.3",
-    "nodemon": "2.0.15"
+    "nodemon": "2.0.15",
+    "nyc": "^15.1.0"
   },
   "workspaces": [
     "api",


### PR DESCRIPTION
### Context
Code coverage refers to the percentage of code in a repo that tests utilize. If tests don't utilize code, the code is considered un covered. `nyc` is a great tool for code coverage and integrated easily with `mocha` so we can use it here. We actually have code coverage currently at 89% in the api but it should at least be at 100%, ideally with multiple test cases for each line.

### Implementation
- Added new `coverage` script
- Installed `nyc`
