### PR TITLE
Add authorization interceptor to client.

### DIFF
--- a/www/pages/_app.js
+++ b/www/pages/_app.js
@@ -3,7 +3,6 @@ import { Provider }    from 'react-redux';
 import { useStore }    from '../store/store';
 import { useEffect }   from 'react';
 import { userRefresh } from '../store/features/user/userSlice';
-import parseCookie     from '../utils/parseCookie';
 
 import '../styles/globals.css';
 
@@ -11,13 +10,9 @@ function MyApp({ Component, pageProps }) {
   const store = useStore({});
 
   useEffect( () => {
-    const token = parseCookie( document.cookie, 'agenda-auth' );
-
-    if ( token ) {
-      store.dispatch(
-        userRefresh( token )
-      );
-    }
+    store.dispatch(
+      userRefresh()
+    );
   });
 
   return (

--- a/www/store/client.js
+++ b/www/store/client.js
@@ -1,8 +1,18 @@
-import axios from "axios";
+import axios       from 'axios';
+import parseCookie from '../utils/parseCookie';
 
 const client = axios.create({
-  baseURL: "http://localhost:4000",
+  baseURL: 'http://localhost:4000',
   timeout: 1000
+});
+
+client.interceptors.request.use( config => {
+  config.headers['authorization'] = parseCookie(
+    document.cookie,
+    'agenda-auth'
+  );
+
+  return config;
 });
 
 export default client;


### PR DESCRIPTION
### Context
I did a bit of work with cookie parsing stuff but this was the coolest part. Axios (our http client) allows you do add interceptors (its the middleware pattern) where you can modify requests and responses. Here we add an interceptor that parses the `document.cookie` with a new `parseCookie` util I made (an improvement over our previous implementation) and if there is an auth token, adds it to the `authorization` header of the request.
