### PR TITLE
Request Logging Utility

### DIFF
--- a/api/lib/middleware/req-logger.js
+++ b/api/lib/middleware/req-logger.js
@@ -1,0 +1,16 @@
+const log = require('@starryinternet/jobi');
+
+function reqLog( req, res, next ) {
+  try {
+
+    log.info( '*' + req.originalUrl );
+    log.debug( 'request params: ' + JSON.stringify( req.params ) );
+    log.debug( 'request body: ' + JSON.stringify( req.body ) );
+    log.trace( req );
+
+  } catch ( error ) {}
+
+  next();
+}
+
+module.exports = reqLog;

--- a/api/lib/routes/index.js
+++ b/api/lib/routes/index.js
@@ -1,6 +1,6 @@
-const router = require('express').Router();
-const auth   = require('../middleware/authenticate');
-
+const router      = require('express').Router();
+const auth        = require('../middleware/authenticate');
+const reqLogger   = require('../middleware/req-logger');
 const health      = require('./health');
 const user        = require('./user');
 const meeting     = require('./meeting');
@@ -8,9 +8,9 @@ const topic       = require('./topic');
 const participant = require('./participant');
 
 router.use( '/health', health );
-router.use( '/user', user );
-router.use( '/meeting', auth, meeting );
-router.use( '/topic', auth, topic );
-router.use( '/participant', auth, participant );
+router.use( '/user', reqLogger, user );
+router.use( '/meeting', reqLogger, auth, meeting );
+router.use( '/topic', reqLogger, auth, topic );
+router.use( '/participant', reqLogger, auth, participant );
 
 module.exports = router;

--- a/api/test/tests/middlware/req-logger.js
+++ b/api/test/tests/middlware/req-logger.js
@@ -1,0 +1,23 @@
+const sinon  = require('sinon');
+const rewire = require('rewire');
+
+const modulePath = '../../../lib/middleware/req-logger';
+
+describe( 'lib/middleware/req-logger', () => {
+
+  before( () => {
+    this.module = rewire( modulePath );
+  });
+
+  it( 'should call next() regardless of failure', () => {
+    const next = sinon.stub().resolves();
+    const log  = sinon.stub().throws( new Error('error') );
+
+    this.module.__set__({ log });
+
+    this.module( {}, {}, next );
+
+    sinon.assert.calledOnce( next );
+  });
+
+});


### PR DESCRIPTION
### Context

We have a lot of copy pasta for request logging this will eliminate the need a lot of it. When running the app with `NODE_DEBUG=debug`, the requests url path will be logged as well as its body and params. With `NODE_DEBUG=trace`, the entire request object will be logged. The lowest level, `NODE_DEBUG=info`, will only show the request url path. Without `NODE_DEBUG` nothing will be logged.