### PR TITLE
Switch from cookies to session storage

### DIFF
--- a/www/components/Bundles/Meeting/HeaderForm.js
+++ b/www/components/Bundles/Meeting/HeaderForm.js
@@ -7,7 +7,7 @@ function HeaderForm( props ) {
     <div className={styles.meetingBar}>
       <form className={styles.form}>
         <Input
-          value={ props.meetingName }
+          value={props.meetingName}
           placeholder="Meeting Name"
           onChange={props.setMeetingName}
           size="xl"

--- a/www/components/Bundles/Meeting/ParticipantsForm.js
+++ b/www/components/Bundles/Meeting/ParticipantsForm.js
@@ -6,9 +6,12 @@ import ChipForm from '../../ChipForm';
 function ParticipantsForm( props ) {
   return (
     <div className={styles.container}>
-      <h2>Participants</h2>
-      <p>Owner</p>
-      <Chip text={props.owner} icon={true} />
+      <h3>Owner</h3>
+      <Chip
+        text={props.owner}
+        icon={true}
+      />
+      <br/>
       <ChipForm
         items={props.participants}
         itemKey='email'

--- a/www/components/Bundles/Meeting/TopicsForm.js
+++ b/www/components/Bundles/Meeting/TopicsForm.js
@@ -4,7 +4,6 @@ import ChipForm from '../../ChipForm';
 function TopicsForm( props ) {
   return (
     <div className={styles.container}>
-      <h2>Topics</h2>
       <ChipForm
         items={props.topics}
         setItems={props.setTopics}

--- a/www/components/Button.js
+++ b/www/components/Button.js
@@ -13,12 +13,10 @@ const Button = ({
   varient,
   stretch,
   children,
-  className
+  customClass
 }) => {
 
   const [ open, setOpen ] = useState( false );
-
-
 
   let buttonStyles = styles.btn;
   // size cases
@@ -74,7 +72,7 @@ const Button = ({
       break;
   }
 
-  buttonStyles = className ? buttonStyles + ' ' + className : buttonStyles;
+  buttonStyles = customClass ? buttonStyles + ' ' + customClass : buttonStyles;
 
   const buttonRef = useRef( null );
   useClickAway( buttonRef, () => setOpen( false ) );

--- a/www/components/ChipForm.js
+++ b/www/components/ChipForm.js
@@ -65,8 +65,8 @@ function ChipForm( props ) {
   });
 
   return (
-    <div>
-      <p>{ props.itemName }s</p>
+    <div className={styles.chipForm}>
+      <h3>{ props.itemName }s</h3>
       <div className={styles.chipContainer}>
         {chips}
       </div>
@@ -81,9 +81,10 @@ function ChipForm( props ) {
         <Button
           varient='secondary'
           name="submit"
+          size="medium"
           onClick={handleSubmit}
           text="add"
-          className={styles.addButton}
+          customClass={styles.addButton}
         />
       </div>
     </div>

--- a/www/components/DropDown.js
+++ b/www/components/DropDown.js
@@ -5,19 +5,19 @@ import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 import LogoutIcon from '@material-ui/icons/ExitToApp';
 
 import { userLogout } from '../store/features/user/userSlice';
+
 import { useSelector, useDispatch } from 'react-redux';
 
 const selectUser = ( state ) => state.user;
 
 const DropDown = () => {
   const dispatch = useDispatch();
+  const user     = useSelector( selectUser );
+  const user_id  = user._id || '';
 
   const logout = () => {
     dispatch( userLogout() );
   };
-
-  const user = useSelector( selectUser );
-  const user_id = user._id || '';
 
   return (
     <div className={styles.container}>

--- a/www/components/Nav.js
+++ b/www/components/Nav.js
@@ -32,10 +32,18 @@ const Nav = () => {
 
           <div className={styles.login}>
             <Link href="/login">
-              <Button varient="secondary" text="Login"/>
+              <Button
+                varient="secondary"
+                text="Login"
+                className={styles.navButton}
+              />
             </Link>
             <Link href="/register">
-              <Button varient="secondary" text="Sign Up" />
+              <Button
+                varient="secondary"
+                text="Sign Up"
+                className={styles.navButton}
+              />
             </Link>
           </div>
         </nav>
@@ -63,13 +71,12 @@ const Nav = () => {
               />
             </Link>
           </div>
-
           <Button
             id="dropDownButton"
             text={user.username}
             icon={<AccountCircleIcon />}
             varient="icon"
-            size="small"
+            size="medium"
           >
             <DropDown />
           </ Button>

--- a/www/pages/index.js
+++ b/www/pages/index.js
@@ -1,11 +1,6 @@
 import styles from '../styles/Home.module.css';
-import Button from '../components/Button';
-import { useState } from 'react';
-import SnackBar from '@material-ui/core/Snackbar'
 
 const Home = () => {
-  const [ open, setOpen ] = useState( false );
-
   return (
     <>
       <div className={styles.homeContainer}>
@@ -18,8 +13,6 @@ const Home = () => {
           overall user management of files, disks, and network volumes.
         </p>
       </div>
-      <Button text="click for a snackbar" onClick={() => setOpen( !open )}/>
-      <SnackBar open={open} onClose={() => setOpen( !open )} text="tom hudson sent you a new meeting" />
     </>
   );
 };

--- a/www/pages/login.js
+++ b/www/pages/login.js
@@ -29,9 +29,7 @@ const Login = props => {
   return (
     <div className={styles.formContainer}>
       <form>
-        <h1 className={styles.formTitle}>
-          Login
-        </h1>
+        <h1 className={styles.formTitle}>Login</h1>
         <Input
           name='username'
           type='text'
@@ -54,8 +52,8 @@ const Login = props => {
           onClick={handleSubmit}
           text='Login'
           size='medium'
-          stretch='wide'
           varient='secondary'
+          customClass={styles.loginButton}
         />
       </form>
     </div>

--- a/www/pages/meeting/[id]/index.js
+++ b/www/pages/meeting/[id]/index.js
@@ -6,7 +6,11 @@ import Button from '../../../components/Button';
 import Snackbar from '../../../components/Snackbar';
 
 import { useEffect, useState } from 'react';
-import { saveMeeting, fetchMeeting } from '../../../store/features/meetings/meetingSlice';
+import {
+  saveMeeting,
+  fetchMeeting
+} from '../../../store/features/meetings/meetingSlice';
+
 import { useSelector } from 'react-redux';
 
 import styles from '../../../styles/MeetingPage.module.css';
@@ -100,9 +104,9 @@ const Meeting = props => {
       />
       <Button
         varient='secondary'
-        className={styles.meetingButton}
+        customClass={styles.meetingButton}
         onClick={handleSubmit}
-        text='submit'
+        text='save'
       />
       <Snackbar
         message='Save Successful'

--- a/www/pages/register.js
+++ b/www/pages/register.js
@@ -32,7 +32,7 @@ const Register = props => {
     <div className={styles.formContainer}>
       <form>
         <h1 className={styles.formTitle}>
-            Register
+          Sign Up
         </h1>
         <Input
           name='email'
@@ -63,9 +63,9 @@ const Register = props => {
         />
         <Button
           onClick={handleSubmit}
-          text='Register'
+          text='Sign Up'
           size='medium'
-          stretch='wide'
+          customClass={styles.loginButton}
           varient='secondary'
         />
       </form>

--- a/www/store/client.js
+++ b/www/store/client.js
@@ -1,5 +1,4 @@
-import axios       from 'axios';
-import parseCookie from '../utils/parseCookie';
+import axios from 'axios';
 
 const client = axios.create({
   baseURL: 'http://localhost:4000',
@@ -7,10 +6,8 @@ const client = axios.create({
 });
 
 client.interceptors.request.use( config => {
-  config.headers['authorization'] = parseCookie(
-    document.cookie,
-    'agenda-auth'
-  );
+  const token = window.sessionStorage.getItem('agenda-auth');
+  config.headers['authorization'] = token;
 
   return config;
 });

--- a/www/store/features/ui/uiSlice.js
+++ b/www/store/features/ui/uiSlice.js
@@ -21,7 +21,6 @@ export default ( state = initialState, action ) => {
  */
 export const toggleDrawer = () => {
   return function toggleDrawer( dispatch, getState ) {
-    console.log('toggleDrawer');
     dispatch({ type: 'ui/toggleDrawer', payload: {} });
   };
 };

--- a/www/store/features/user/userSlice.js
+++ b/www/store/features/user/userSlice.js
@@ -1,5 +1,4 @@
 import client from '../../client';
-import  parseCookie  from '../../../utils/parseCookie';
 
 const initialState = {
   token: null,
@@ -47,7 +46,7 @@ export const userRegister = ({ email, username, password }) => {
         }
       );
 
-      document.cookie = `agenda-auth=${ data.token }`;
+      window.sessionStorage.setItem( 'agenda-auth', data.token );
 
       dispatch({
         type: 'user/register',
@@ -82,7 +81,7 @@ export const userLogin = ({ username, password }) => {
         }
       );
 
-      document.cookie = `agenda-auth=${ data.token }`;
+      window.sessionStorage.setItem( 'agenda-auth', data.token );
 
       dispatch({
         type: 'user/login',
@@ -108,7 +107,7 @@ export const userLogin = ({ username, password }) => {
  */
 export const userRefresh = () => {
   return async function refreshUser( dispatch, getState ) {
-    const token = parseCookie( document.cookie, 'agenda-auth' );
+    const token = sessionStorage.getItem('agenda-auth');
 
     if ( token ) {
       try {
@@ -130,7 +129,7 @@ export const userRefresh = () => {
         });
 
       } catch ( err ) {
-        console.log( err );
+        console.error( err );
       }
     }
   };
@@ -142,12 +141,7 @@ export const userRefresh = () => {
  */
 export const userLogout = () => {
   return async function logoutUser( dispatch, getState ) {
-    const cookie = document.cookie
-    .match( new RegExp( '(^| )' + 'agenda-auth' + '=([^;]+)' ) );
-
-    if ( cookie ) {
-      document.cookie = `${ cookie }; expires=Thu, 01 Jan 1970 00:00:00 UTC`;
-    }
+    window.sessionStorage.removeItem('agenda-auth');
 
     window.location.href = '/';
 

--- a/www/styles/Bundles/Meeting/HeaderForm.module.css
+++ b/www/styles/Bundles/Meeting/HeaderForm.module.css
@@ -1,8 +1,7 @@
 .meetingBar {
   display: flex;
-  margin-bottom: 2rem;
+  margin: 2rem;
   margin-left: 3rem;
-  margin-right: 3rem;
 }
 
 .form {

--- a/www/styles/Bundles/Meeting/ParticipantsForm.module.css
+++ b/www/styles/Bundles/Meeting/ParticipantsForm.module.css
@@ -9,6 +9,6 @@
   border-radius: 10px;
 }
 
-.container h2 {
-  margin-top: -.25rem;
+.container h3 {
+  margin: 0;
 }

--- a/www/styles/Bundles/Meeting/TopicsForm.module.css
+++ b/www/styles/Bundles/Meeting/TopicsForm.module.css
@@ -9,6 +9,6 @@
   border-radius: 10px;
 }
 
-.container h2 {
-  margin-top: -5px;
+.container h3 {
+  margin: 0;
 }

--- a/www/styles/Button.module.css
+++ b/www/styles/Button.module.css
@@ -1,6 +1,5 @@
 .btn {
   border: none;
-  min-width: 7rem;
   justify-content: center;
   display: flex;
   flex-direction: row;
@@ -20,8 +19,8 @@
 }
 
 .medium {
-  padding: .5rem;
-  font-size: 1.25rem;
+  padding: .5rem 1.5rem .5rem 1.5rem;
+  font-size: 1.05rem;
 }
 
 .small {
@@ -66,6 +65,7 @@
   color: var(--agendaSecondary);
   min-width: 0px;
   padding: 0.2rem;
+  margin-top: 0.2rem;
 }
 
 .icon:hover {
@@ -74,7 +74,6 @@
 
 .iconContainer {
   margin-right: .5rem;
-  margin-top: auto;
 }
 
 .disabled {

--- a/www/styles/Chip.module.css
+++ b/www/styles/Chip.module.css
@@ -6,7 +6,7 @@
   justify-content: space-between;
   align-items: center;
   width: fit-content;
-  margin-left: .25rem;
+  margin: .25rem;
   font-weight: 200;
 }
 

--- a/www/styles/ChipForm.module.css
+++ b/www/styles/ChipForm.module.css
@@ -9,6 +9,11 @@
 
 .chipContainer {
   display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: start;
+  flex-wrap: wrap;
+  min-height: 45px;
 }
 
 .inputContainer {
@@ -17,6 +22,6 @@
 }
 
 .addButton {
-  margin-right: 0px;
-  margin-left: 2rem;
+  margin-left: 1.5rem;
+  margin-top: -.4rem;
 }

--- a/www/styles/Drawer.module.css
+++ b/www/styles/Drawer.module.css
@@ -9,7 +9,7 @@
   border: 1px solid var(--agendaThree);
   background-color: var(--menuColor);
   height: 100%;
-  transition: width 600ms;
+  transition: width 400ms;
   overflow: hidden;
   margin-top: 1rem;
   border-radius: 0rem .5rem .5rem 0rem;
@@ -48,9 +48,9 @@
 
 .arrowClose {
   transform: rotate(180deg) translate( 0, -.4rem );
-  transition: transform 600ms linear;
+  transition: transform 400ms linear;
 }
 .arrowOpen {
   transform: rotate(0deg) translate( 0, .7rem );
-  transition: transform 600ms linear;
+  transition: transform 400ms linear;
 }

--- a/www/styles/LoadingIcon.module.css
+++ b/www/styles/LoadingIcon.module.css
@@ -15,7 +15,6 @@
   position: relative;
 }
 
-
 .hourHand {
   position: absolute;
   height: 30%;

--- a/www/styles/MeetingPage.module.css
+++ b/www/styles/MeetingPage.module.css
@@ -1,3 +1,5 @@
-.meetingButton{
-  margin-left: 50px;
+.meetingButton {
+  margin-left: auto;
+  margin-right: 50px;
+  margin-bottom: 50px;
 }

--- a/www/styles/Nav.module.css
+++ b/www/styles/Nav.module.css
@@ -37,6 +37,14 @@
   margin-left: 1rem;
 }
 
+.nav ul li a {
+  margin: .5rem 1rem;
+}
+
+.nav Button {
+  margin: 1rem;
+}
+
 .navLoggedIn ul li a {
   margin: .5rem 1.5rem;
 }
@@ -45,10 +53,6 @@
   margin: 4.5rem 0px;
 }
 
-.nav ul li a {
-  margin: .5rem 1rem;
-}
-
-.nav Button {
-  margin: .5rem 1rem;
+.navButton {
+  width: 7rem;
 }

--- a/www/styles/Register.module.css
+++ b/www/styles/Register.module.css
@@ -5,28 +5,28 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  background: var(--agendaBg );
 }
 
 .formContainer form {
   background-color: var(--menuColor);
   border-radius: 5px;
-  display: flex;
-  flex-direction: column; 
-  justify-content: center;
-  align-items: center;
   padding: 20px 30px 30px 30px;
-}
-
-.formContainer Button {
-  margin: 15px 0px 0px 0px;
+  opacity: 85%;
 }
 
 .formTitle {
+  width: 100%;
   color: var(--agendaSecondary);
-  margin: 0px 10px 15px 10px;
+  margin-bottom: 20px;
+  text-align: center;
 }
 
 .formContainer Input {
   margin: 0px 0px 20px 0px;
 }
 
+.loginButton {
+  margin-top: 20px;
+  margin-left: auto;
+}


### PR DESCRIPTION
### Context
Cookies are sent with requests automatically which exposes us to cross site request forgery attacks that would allow attackers to steal our users jwts thus gaining access to all their permission's until the jwt expires. Session storage is also much less exposes to cross site scripting and easier to work with so its pretty much all wins here.

### Implementation

Switch from `document.cookie` api to `window.sessionStorage` api for storage of our jwts. I also made a few ui changes but nothing significant.

### Merge Checklist
- [x] Correct Target Branch
- [x] Pre-Review Diff Check
- [x] PR Description
- [x] Add Reviewers and Assignees
- [x] Review Complete
- [x] Rebase
- [x] Rebase Approved
