### PR TITLE
Fix: Meetings not saving with owner ID

### DIFF
--- a/api/lib/controllers/meeting.js
+++ b/api/lib/controllers/meeting.js
@@ -78,7 +78,7 @@ module.exports = {
     try {
       const name       = req.body.name;
       const date       = req.body.date;
-      const owner_id   = req.body.ownerId;
+      const owner_id   = req.body.owner_id;
       const meeting_id = req.body.meeting_id || new ObjectID();
 
       let topics       = req.body.topics || null;
@@ -92,7 +92,7 @@ module.exports = {
 
         meeting = await Meeting.findOneAndUpdate(
           { _id: meeting_id },
-          { name, date, owner_id },
+          { name, owner_id, date },
           {
             upsert: true,
             new: true

--- a/www/pages/user/[id]/index.js
+++ b/www/pages/user/[id]/index.js
@@ -21,7 +21,7 @@ const User = () => {
     }
   }, [ user ] );
 
-  const loaded = ownedMeetings.length || participantMeetings.length;
+  const loaded = ownedMeetings.length >= 0 || participantMeetings >= 0;
 
   //TODO filter and sort for inbox
 

--- a/www/pages/user/[id]/index.js
+++ b/www/pages/user/[id]/index.js
@@ -21,7 +21,7 @@ const User = () => {
     }
   }, [ user ] );
 
-  const loaded = ownedMeetings.length >= 0 || participantMeetings >= 0;
+  const loaded = ownedMeetings.length >= 0 || participantMeetings.length >= 0;
 
   //TODO filter and sort for inbox
 

--- a/www/store/features/meetings/meetingSlice.js
+++ b/www/store/features/meetings/meetingSlice.js
@@ -54,17 +54,17 @@ export const fetchMeeting = ( meeting_id ) => {
 
 export const saveMeeting = ( meeting ) => {
   return async function MeetingSave( dispatch, getState ) {
-      await client.post(
-        'meeting',
-        meeting
-      );
+    await client.post(
+      'meeting',
+      meeting
+    );
 
-      dispatch({
-        type: 'meeting/save',
-        payload: {
-          meeting
-        }
-      });
+    dispatch({
+      type: 'meeting/save',
+      payload: {
+        meeting
+      }
+    });
 
   };
 };


### PR DESCRIPTION
### Context
  - Meetings were failing to save with owner ID's this whole time. Crazy that we never noticed this. Also strange it was still succeeding at all even with owner ID being a required field.
  - Inbox page would load indefinitely if user had no meetings. Changed the way we check for meetings

### Implementation
  - Fixed typo
  - Changed the way we check for meetings on the Inbox page. If .length returned 0 page would not load.

### Merge Checklist
- [x] Correct Target Branch
- [x] Pre-Review Diff Check
- [x] PR Description
- [x] Add Reviewers and Assignees
- [ ] Review Complete
- [ ] Rebase
- [ ] Rebase Approved

```   ,------.
   `-____-'        ,-----------.
    ,i--i.         |           |
   / @  @ \       /  HEE HEE!  |
  | -.__.- | ___-'             J
   \.    ,/ """"""""""""""""""'
   ,\""""/.
 ,'  `--'  `.
(_,i'    `i._)
   |      |
   |  ,.  |
   | |  | |      -bodom-
   `-'  `-'
```
