### PR TITLE
Topic description, status, and relevant API

### DIFF
--- a/api/lib/controllers/topic.js
+++ b/api/lib/controllers/topic.js
@@ -43,5 +43,22 @@ module.exports = {
     } catch ( error ) {
       response.status( 500 ).send( error );
     }
+  },
+
+  status: async( request, response ) => {
+    try {
+      const { _id }    = request.params;
+      const { status } = request.body;
+
+      const res = await Topic.findOneAndUpdate(
+        { _id },
+        { status },
+        { new: true }
+      );
+
+      response.status( 200 ).send( res );
+    } catch ( err ) {
+      response.status( 500 ).send( err );
+    }
   }
 };

--- a/api/lib/controllers/topic.js
+++ b/api/lib/controllers/topic.js
@@ -3,15 +3,33 @@ const Topic = require('../models/topic');
 
 module.exports = {
   create: async( req, res ) => {
-    const { name, meeting_id, likes } = req.body;
+    const newTopic = req.body;
 
     try {
-      const topic = await Topic.create({ name, meeting_id, likes });
+      const topic = await Topic.create( newTopic );
 
       res.status( 201 ).send( topic );
     } catch ( error ) {
       log.error( 'Error creating topic: ' + error.message );
       res.status( 500 ).send( error.message );
+    }
+  },
+
+  update: async( request, response ) => {
+    const updates = request.body;
+    const _id     = request.params;
+
+    try {
+      const topic = await Topic.findOneAndUpdate(
+        { _id },
+        updates,
+        { new: true }
+      );
+
+      response.status( 200 ).send( topic );
+
+    } catch ( error ) {
+      response.status( 500 ).send( error.message );
     }
   },
 

--- a/api/lib/models/topic.js
+++ b/api/lib/models/topic.js
@@ -8,6 +8,10 @@ const topicSchema = new mongoose.Schema(
       type: String,
       required: true
     },
+    description: {
+      type: String,
+      required: true
+    },
     meeting_id: {
       type: Schema.Types.ObjectId, ref: 'Meeting',
       required: true
@@ -15,7 +19,8 @@ const topicSchema = new mongoose.Schema(
     likes: [ String ],
     status: {
       type: String,
-      default: 'open'
+      default: 'open',
+      required: true
     }
   },
   {
@@ -57,6 +62,7 @@ async function saveMeetingTopics({ meeting_id, savedTopics }) {
     return {
       _id: topic._id || undefined,
       name: topic.name,
+      description: topic.description,
       meeting_id,
       likes: topic.likes || []
     };

--- a/api/lib/models/topic.js
+++ b/api/lib/models/topic.js
@@ -12,7 +12,11 @@ const topicSchema = new mongoose.Schema(
       type: Schema.Types.ObjectId, ref: 'Meeting',
       required: true
     },
-    likes: [ String ]
+    likes: [ String ],
+    status: {
+      type: String,
+      default: 'open'
+    }
   },
   {
     timestamp: true

--- a/api/lib/routes/topic.js
+++ b/api/lib/routes/topic.js
@@ -3,5 +3,6 @@ const topicController = require('../controllers/topic');
 
 router.post( '/', topicController.create );
 router.patch( '/:_id/like', topicController.like );
+router.patch( '/:_id/status', topicController.status );
 
 module.exports = router;

--- a/api/lib/routes/topic.js
+++ b/api/lib/routes/topic.js
@@ -2,6 +2,7 @@ const router          = require('express').Router();
 const topicController = require('../controllers/topic');
 
 router.post( '/', topicController.create );
+router.post( '/:_id', topicController.update );
 router.patch( '/:_id/like', topicController.like );
 router.patch( '/:_id/status', topicController.status );
 

--- a/api/test/fakes/topic.js
+++ b/api/test/fakes/topic.js
@@ -6,6 +6,7 @@ const topic = ( opts ) => {
     name: faker.commerce.productName(),
     meeting_id: new ObjectId,
     likes: [ 'bryan@bacon.com' ],
+    status: 'open',
     ...opts
   };
 };

--- a/api/test/fakes/topic.js
+++ b/api/test/fakes/topic.js
@@ -4,6 +4,7 @@ const ObjectId = require('mongoose').Types.ObjectId;
 const topic = ( opts ) => {
   return {
     name: faker.commerce.productName(),
+    description: faker.company.bs(),
     meeting_id: new ObjectId,
     likes: [ 'bryan@bacon.com' ],
     status: 'open',

--- a/api/test/tests/controllers/topic.js
+++ b/api/test/tests/controllers/topic.js
@@ -73,6 +73,7 @@ describe( 'api/lib/controllers/topic', () => {
 
     it( 'should not create topic without name', async() => {
       const topicWithoutName = topicFaker({ name: '' });
+
       const errorRegex = /^Topic validation failed: name/;
 
       try {
@@ -109,6 +110,46 @@ describe( 'api/lib/controllers/topic', () => {
       const res = await Topic.find({});
 
       assert.strictEqual( res.length, 0 );
+    });
+
+  });
+
+  describe( '#update', () => {
+
+    beforeEach( async() => {
+      this.topic = await Topic.create( topicFaker() );
+    });
+
+    it( 'should update topic name', async() => {
+      const res = await client.post(
+        '/topic/' + this.topic._id,
+        { ...this.topic._doc, name: 'new name' }
+      );
+
+      assert.strictEqual( res.status, 200 );
+      assert.strictEqual( res.data.name, 'new name' );
+
+      const [ topic ] = await Topic.find({ _id: this.topic._id });
+
+      assert.strictEqual( topic.name, 'new name' );
+      assert.strictEqual( topic.status, this.topic.status );
+      assert.deepEqual( topic.likes, this.topic.likes );
+    });
+
+    it( 'should update topic description', async() => {
+      const res = await client.post(
+        '/topic/' + this.topic._id,
+        { ...this.topic._doc, description: 'new description' }
+      );
+
+      assert.strictEqual( res.status, 200 );
+      assert.strictEqual( res.data.description, 'new description' );
+
+      const [ topic ] = await Topic.find({ _id: this.topic._id });
+
+      assert.strictEqual( topic.description, 'new description' );
+      assert.strictEqual( topic.status, this.topic.status );
+      assert.deepEqual( topic.likes, this.topic.likes );
     });
 
   });

--- a/api/test/tests/controllers/topic.js
+++ b/api/test/tests/controllers/topic.js
@@ -149,4 +149,26 @@ describe( 'api/lib/controllers/topic', () => {
 
   });
 
+  describe( '#status', () => {
+
+    beforeEach( async() => {
+      this.topic = await Topic.create( topicFaker() );
+    });
+
+    it( 'should set the topics status', async() => {
+      const res = await client.patch(
+        '/topic/' + this.topic._id + '/status',
+        { status: 'discussed' }
+      );
+
+      assert.strictEqual( res.status, 200 );
+      assert.strictEqual( res.data.status, 'discussed' );
+
+      const [ topic ] = await Topic.find({});
+
+      assert.strictEqual( topic.status, 'discussed' );
+      assert.strictEqual( topic.name, this.topic.name );
+    });
+  });
+
 });


### PR DESCRIPTION
### Context

[Topic Status Prop Ticket](https://www.notion.so/thomashudsonnotes/Topic-Status-Prop-API-7ef6a765bd4a4c6ea40890c39c6a2517)
[Topic Description Prop Ticket](https://www.notion.so/thomashudsonnotes/Topic-Description-Prop-Update-API-fe0c6f030b794ac68d8b3017078408ca)

We recently decided that topic's should have `description`s and that we needed a `status` prop to persist meeting state while the meeting is ongoing. This PR adds these features.

### Implementation

- Added `description` and `status` properties to the `Topic` schema
- Added `update` api for topics
- Added `status` api for topics (we use a separate route to allow for different permissions)

### Merge Checklist
- [x] Correct Target Branch
- [x] Pre-Review Diff Check
- [x] PR Description
- [x] Add Reviewers and Assignees
- [ ] Review Complete
- [ ] Rebase
- [ ] Rebase Approved
