### PR TITLE
Fixed Hard Reload Issue

### DIFF
--- a/www/pages/meeting/[id]/index.js
+++ b/www/pages/meeting/[id]/index.js
@@ -66,7 +66,7 @@ const Meeting = ( props ) => {
     };
 
     loadMeeting();
-  }, [ user, props.store, router.query ] );
+  }, [ user, props.store, router.query.id ] );
 
   useEffect( () => {
     const save = async() => {

--- a/www/pages/meeting/[id]/meet.js
+++ b/www/pages/meeting/[id]/meet.js
@@ -21,25 +21,27 @@ const Meet = ( props ) => {
     const loadMeeting = async() => {
       const meeting_id = router.query.id;
 
-      await props.store.dispatch( fetchMeeting( meeting_id ) );
+      if ( meeting_id ) {
+        await props.store.dispatch( fetchMeeting( meeting_id ) );
 
-      const { meetings: { openMeeting } } = props.store.getState();
+        const { meetings: { openMeeting } } = props.store.getState();
 
-      setMeeting({
-        ...openMeeting,
-        topics: openMeeting.topics.map( topic => {
-          return {
-            ...topic,
-            discussed: false
-          };
-        })
-      });
+        setMeeting({
+          ...openMeeting,
+          topics: openMeeting.topics.map( topic => {
+            return {
+              ...topic,
+              discussed: false
+            };
+          })
+        });
 
-      setLoading( false );
+        setLoading( false );
+      }
     };
 
     loadMeeting();
-  }, [ props.store ] );
+  }, [ router.query.id, props.store ] );
 
   useEffect( () => {
     const saveTopic = async() => {
@@ -55,7 +57,7 @@ const Meet = ( props ) => {
     setTakeaways([ ...takeaways, takeaway ]);
   };
 
-  if ( !meeting ) {
+  if ( loading ) {
     return (
       <div className={styles.loadingContainer}>
         <LoadingIcon />

--- a/www/pages/meeting/[id]/voting.js
+++ b/www/pages/meeting/[id]/voting.js
@@ -26,7 +26,6 @@ const Voting = ( props ) => {
       const meeting_id = router.query.id;
 
       if ( meeting_id ) {
-        console.log( meeting_id );
         await props.store.dispatch( fetchMeeting( meeting_id ) );
 
         const { meetings: { openMeeting } } = props.store.getState();

--- a/www/pages/meeting/[id]/voting.js
+++ b/www/pages/meeting/[id]/voting.js
@@ -13,7 +13,6 @@ import { useRouter }    from 'next/router';
 
 const selectUser = state => state.user;
 
-// TODO get meeting id based on route
 const Voting = ( props ) => {
   const [ liking, setLiking ]   = useState('');
   const [ loading, setLoading ] = useState( true );
@@ -26,29 +25,31 @@ const Voting = ( props ) => {
     const loadMeeting = async() => {
       const meeting_id = router.query.id;
 
-      await props.store.dispatch( fetchMeeting( meeting_id ) );
+      if ( meeting_id ) {
+        console.log( meeting_id );
+        await props.store.dispatch( fetchMeeting( meeting_id ) );
 
-      const { meetings: { openMeeting } } = props.store.getState();
+        const { meetings: { openMeeting } } = props.store.getState();
 
-      setMeeting({
-        ...openMeeting,
-        topics: openMeeting.topics.map( topic => {
-          const userLiked = topic.likes.includes( user.email );
+        setMeeting({
+          ...openMeeting,
+          topics: openMeeting.topics.map( topic => {
+            const userLiked = topic.likes.includes( user.email );
 
-          return {
-            ...topic,
-            discussed: false,
-            userLiked
-          };
-        })
-      });
+            return {
+              ...topic,
+              discussed: false,
+              userLiked
+            };
+          })
+        });
 
-      setLoading( false );
+        setLoading( false );
+      }
     };
 
     loadMeeting();
-  }, [ loading ] );
-
+  }, [ loading, router.query.id, props.store, user.email ] );
 
   useEffect( () => {
     const likeTopic = async() => {
@@ -58,14 +59,12 @@ const Voting = ( props ) => {
       );
 
       setLiking( false );
-      setLoading( true );
     };
 
     if ( liking.length ) {
       likeTopic();
     }
-  }, [ liking ] );
-
+  }, [ liking, user.email ] );
 
   const onLike = ( topic_id ) => {
     meeting.topics = meeting.topics.map( t => {
@@ -79,7 +78,7 @@ const Voting = ( props ) => {
     setLiking( topic_id );
   };
 
-  if ( !meeting ) {
+  if ( loading ) {
     return (
       <div className={styles.loadingContainer}>
         <LoadingIcon />
@@ -104,7 +103,6 @@ const Voting = ( props ) => {
     );
   });
 
-  // dynamically generate topics cards
   return (
     <div className={styles.container}>
       { topicCards }

--- a/www/store/features/theme/themeSlice.js
+++ b/www/store/features/theme/themeSlice.js
@@ -33,12 +33,7 @@ export const pickTheme = ( theme ) => {
 
       dispatch({ type: 'ui/pickTheme', payload: { theme } });
 
-
-      //document.documentElement.setAttribute( 'data-theme',  theme );
-      console.log( theme );
-    } catch ( err ) {
-      console.log( err );
-    }
+    } catch ( err ) {}
   };
 };
 
@@ -48,16 +43,12 @@ export const refreshTheme = () => {
     const user_id = state.user._id;
 
     try {
-      console.log( user_id );
-
       if ( user_id ) {
         const { data } = await client.get( `ui/${ user_id }` );
 
         dispatch({ type: 'ui/refreshTheme', payload: { theme: data.theme } });
       }
 
-    } catch ( err ) {
-      console.log( err );
-    }
+    } catch ( err ) {}
   };
 };


### PR DESCRIPTION
### Context

We had previously been experiencing an issue where hard reloads caused an error in the `useEffect` hook of pages that required a db request. This error was due to the `next/router` instance not being instantiated by the time it was referenced. 

### Implementation

We can avoid this issue by checking if what we need from the `router` is functioning before making the request, and adding the router as a dependency to the `useEffect`. This way we perform no action before the `router` has loaded. We then detect when the `router` has loaded as it is a dependency of the useEffect and finally perform the request that relies on the router.

### Merge Checklist
- [x] Correct Target Branch
- [x] Pre-Review Diff Check
- [x] PR Description
- [x] Add Reviewers and Assignees
- [ ] Review Complete
- [ ] Rebase
- [ ] Rebase Approved
