### PR TITLE
Duplicate Key Issues

### DIFF
--- a/www/components/Bundles/Meeting/TopicsForm.js
+++ b/www/components/Bundles/Meeting/TopicsForm.js
@@ -5,8 +5,16 @@ import { useState } from 'react';
 import Input  from '../../Input';
 import Button from '../../Button';
 
+import { notify } from '../../../store/features/snackbar/snackbarSlice';
+
 import TopicCard from './TopicCard';
 
+/**
+ * Component for listing, adding, updating, and deleting topics
+ * @param {Object} props.store - redux store reference
+ * @param {Object[]} props.topics - array of meeting topics
+ * @param {Function} props.setTopics - method to set the meeting topics
+ */
 function TopicsForm( props ) {
   const [ name, setName ]               = useState('');
   const [ description, setDescription ] = useState('');
@@ -17,6 +25,22 @@ function TopicsForm( props ) {
   };
 
   const addTopic = () => {
+    const duplicates = props.topics.filter( t => {
+      return t.name === name;
+    });
+
+    if ( duplicates.length ) {
+      props.store.dispatch(
+        notify({
+          message: 'Cannot create multiple topics with the same name.',
+          type: 'danger',
+          ms: 4000
+        })
+      );
+
+      return;
+    }
+
     const updatedTopics = [ ...props.topics ];
     updatedTopics.unshift({ name, description });
 
@@ -26,6 +50,22 @@ function TopicsForm( props ) {
   };
 
   const updateTopic = ( index, updated ) => {
+    const duplicates = props.topics.filter( t => {
+      return t.name === name;
+    });
+
+    if ( duplicates.length ) {
+      props.store.dispatch(
+        notify({
+          message: 'Cannot create multiple topics with the same name.',
+          type: 'danger',
+          ms: 4000
+        })
+      );
+
+      return;
+    }
+
     const updatedTopics = [ ...props.topics ];
     updatedTopics.splice( index, 1, updated );
 
@@ -44,9 +84,10 @@ function TopicsForm( props ) {
   if ( props.topics ) {
     for ( let i = 0; i < props.topics.length; i++ ) {
       const topic = props.topics[ i ];
+
       topicCards.push(
         <TopicCard
-          key={topic.name + ' ' + topic.description}
+          key={topic.name}
           index={i}
           topic={topic}
           updateTopic={updateTopic}

--- a/www/components/ChipForm.js
+++ b/www/components/ChipForm.js
@@ -22,13 +22,12 @@ function ChipForm( props ) {
     });
 
     if ( duplicates.length ) {
-      const msg = `${ props.itemName } with name ${ chip } already exists, ` +
-        `do you still want to add ${ chip }?`;
+      const msg = `Cannot create multiple ${ props.itemName }s with the same name`;
 
-      // todo swap with something sexier
-      if ( !window.confirm( msg ) ) {
-        return;
-      }
+      // TODO swap with something sexier
+      window.alert( msg );
+
+      return;
     }
 
     props.items.unshift({ [ props.itemKey ]: chip });

--- a/www/pages/meeting/[id]/index.js
+++ b/www/pages/meeting/[id]/index.js
@@ -122,6 +122,7 @@ const Meeting = ( props ) => {
         setParticipants={setParticipants}
       />
       <TopicsForm
+        store={props.store}
         topics={topics}
         setTopics={setTopics}
       />


### PR DESCRIPTION
### Context

React uses the `key` prop to keep track of elements in an array. If the key prop does not change for an element it does not re-render the element which saves some cycles. However, when multiple elements have the same key prop and one is updated, React will use the first previously rendered version with the same key which is often inaccurate. This caused issues for us with the `TopicForm` and `ChipForm` which we can fix by not allowing duplicate `Topic` names or `Chip` names.

### Implementation

Don't allow duplicate keys in `ChipForm` or `TopicForm`.

### Further Improvement

We probably want to use the new `Input` notification system instead once that gets merged in.

### Merge Checklist
- [x] Correct Target Branch
- [x] Pre-Review Diff Check
- [x] PR Description
- [x] Add Reviewers and Assignees
- [ ] Review Complete
- [ ] Rebase
- [ ] Rebase Approved
