### PR TITLE
Utilize owner_id for objects

### DIFF
--- a/api/lib/controllers/meeting.js
+++ b/api/lib/controllers/meeting.js
@@ -76,10 +76,9 @@ module.exports = {
     let session;
 
     try {
-
       const name       = req.body.name;
       const date       = req.body.date;
-      const owner_id   = req.credentials.sub;
+      const owner_id   = req.body.owner_id;
       const meeting_id = req.body.meeting_id || new ObjectID();
 
       let topics       = req.body.topics || null;
@@ -88,9 +87,6 @@ module.exports = {
       let meeting;
 
       session = await mongoose.connection.startSession();
-
-      console.log('test1');
-      console.log( owner_id );
 
       await session.withTransaction( async() => {
 
@@ -102,12 +98,10 @@ module.exports = {
             new: true
           }
         );
-        console.log('test4');
 
         if ( topics ) {
           topics = await Topic.saveMeetingTopics({
             meeting_id: meeting._id,
-            owner_id,
             savedTopics: topics
           });
         } else {
@@ -115,7 +109,6 @@ module.exports = {
 
           topics = [];
         }
-        console.log('test3');
 
         await Participant.deleteMany({ meeting_id: meeting._id });
 
@@ -132,8 +125,6 @@ module.exports = {
 
         participants = await Participant.find({ meeting_id: meeting._id });
       });
-
-      console.log('test2');
 
       res.status( 201 ).send({
         _id: meeting._id,

--- a/api/lib/controllers/meeting.js
+++ b/api/lib/controllers/meeting.js
@@ -76,9 +76,10 @@ module.exports = {
     let session;
 
     try {
+
       const name       = req.body.name;
       const date       = req.body.date;
-      const owner_id   = req.body.owner_id;
+      const owner_id   = req.credentials.sub;
       const meeting_id = req.body.meeting_id || new ObjectID();
 
       let topics       = req.body.topics || null;
@@ -87,6 +88,9 @@ module.exports = {
       let meeting;
 
       session = await mongoose.connection.startSession();
+
+      console.log('test1');
+      console.log( owner_id );
 
       await session.withTransaction( async() => {
 
@@ -98,10 +102,12 @@ module.exports = {
             new: true
           }
         );
+        console.log('test4');
 
         if ( topics ) {
           topics = await Topic.saveMeetingTopics({
             meeting_id: meeting._id,
+            owner_id,
             savedTopics: topics
           });
         } else {
@@ -109,6 +115,7 @@ module.exports = {
 
           topics = [];
         }
+        console.log('test3');
 
         await Participant.deleteMany({ meeting_id: meeting._id });
 
@@ -125,6 +132,8 @@ module.exports = {
 
         participants = await Participant.find({ meeting_id: meeting._id });
       });
+
+      console.log('test2');
 
       res.status( 201 ).send({
         _id: meeting._id,

--- a/api/lib/controllers/takeaway.js
+++ b/api/lib/controllers/takeaway.js
@@ -3,7 +3,8 @@ const Takeaway = require('../models/takeaway');
 module.exports = {
   create: async( req, res ) => {
     try {
-      const { content, topic_id, owner_id } = req.body;
+      const { content, topic_id } = req.body;
+      const owner_id = req.credentials.sub;
 
       const takeaway = await Takeaway.create({
         content,

--- a/api/lib/controllers/topic.js
+++ b/api/lib/controllers/topic.js
@@ -4,9 +4,10 @@ const Topic = require('../models/topic');
 module.exports = {
   create: async( req, res ) => {
     const newTopic = req.body;
+    const owner_id = req.credentials.sub;
 
     try {
-      const topic = await Topic.create( newTopic );
+      const topic = await Topic.create( newTopic, owner_id );
 
       res.status( 201 ).send( topic );
     } catch ( error ) {

--- a/api/lib/controllers/topic.js
+++ b/api/lib/controllers/topic.js
@@ -4,10 +4,10 @@ const Topic = require('../models/topic');
 module.exports = {
   create: async( req, res ) => {
     const newTopic = req.body;
-    const owner_id = req.credentials.sub;
+    const sub_id = req.credentials.sub;
 
     try {
-      const topic = await Topic.create( newTopic, owner_id );
+      const topic = await Topic.create({ ...newTopic, sub_id });
 
       res.status( 201 ).send( topic );
     } catch ( error ) {
@@ -18,18 +18,27 @@ module.exports = {
 
   update: async( request, response ) => {
     const updates = request.body;
-    const _id     = request.params;
+    const { _id } = request.params;
+
+    const sub_id = request.credentials.sub;
 
     try {
-      const topic = await Topic.findOneAndUpdate(
+      const topic = await Topic.findOne({ _id });
+
+      if ( sub_id !== topic.owner_id.toString() ) {
+        return response.status( 403 ).send('unauthorized');
+      }
+
+      const topicUpdated = await Topic.findOneAndUpdate(
         { _id },
-        updates,
+        { ...updates, owner_id: sub_id },
         { new: true }
       );
 
-      response.status( 200 ).send( topic );
+      response.status( 200 ).send( topicUpdated );
 
     } catch ( error ) {
+      log.error( error );
       response.status( 500 ).send( error.message );
     }
   },

--- a/api/lib/models/topic.js
+++ b/api/lib/models/topic.js
@@ -16,6 +16,11 @@ const topicSchema = new mongoose.Schema(
       type: Schema.Types.ObjectId, ref: 'Meeting',
       required: true
     },
+    owner_id: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true
+    },
     likes: [ String ],
     status: {
       type: String,
@@ -38,7 +43,7 @@ const topicSchema = new mongoose.Schema(
  *
  * @returns {Promise<Object[]>} - meeting's associated topics after save
  */
-async function saveMeetingTopics({ meeting_id, savedTopics }) {
+async function saveMeetingTopics({ meeting_id, owner_id, savedTopics }) {
   logger.debug(`#saveMeetingTopics models/topic`);
 
   const writeOperations = [];
@@ -63,6 +68,7 @@ async function saveMeetingTopics({ meeting_id, savedTopics }) {
       _id: topic._id || undefined,
       name: topic.name,
       description: topic.description,
+      owner_id,
       meeting_id,
       likes: topic.likes || []
     };

--- a/api/lib/models/topic.js
+++ b/api/lib/models/topic.js
@@ -17,8 +17,7 @@ const topicSchema = new mongoose.Schema(
       required: true
     },
     owner_id: {
-      type: Schema.Types.ObjectId,
-      ref: 'User',
+      type: Schema.Types.ObjectId, ref: 'User',
       required: true
     },
     likes: [ String ],
@@ -43,7 +42,7 @@ const topicSchema = new mongoose.Schema(
  *
  * @returns {Promise<Object[]>} - meeting's associated topics after save
  */
-async function saveMeetingTopics({ meeting_id, owner_id, savedTopics }) {
+async function saveMeetingTopics({ meeting_id, savedTopics }) {
   logger.debug(`#saveMeetingTopics models/topic`);
 
   const writeOperations = [];
@@ -68,7 +67,7 @@ async function saveMeetingTopics({ meeting_id, owner_id, savedTopics }) {
       _id: topic._id || undefined,
       name: topic.name,
       description: topic.description,
-      owner_id,
+      owner_id: topic.owner_id,
       meeting_id,
       likes: topic.likes || []
     };

--- a/api/test/fakes/topic.js
+++ b/api/test/fakes/topic.js
@@ -6,6 +6,7 @@ const topic = ( opts ) => {
     name: faker.commerce.productName(),
     description: faker.company.bs(),
     meeting_id: new ObjectId,
+    owner_id: new ObjectId,
     likes: [ 'bryan@bacon.com' ],
     status: 'open',
     ...opts

--- a/api/test/tests/controllers/takeway.js
+++ b/api/test/tests/controllers/takeway.js
@@ -7,7 +7,7 @@ const takeawayFaker = require('../../fakes/takeaway');
 const topicFaker    = require('../../fakes/topic');
 const Takeaway      = require('../../../lib/models/takeaway');
 
-describe( 'api/lib/controllers/topic', () => {
+describe( 'api/lib/controllers/takeaway', () => {
 
   before( async() => {
     await api.start();
@@ -42,8 +42,11 @@ describe( 'api/lib/controllers/topic', () => {
   describe( '#create', () => {
     const path = '/takeaway';
 
-    it( 'should create topic with valid topic', async() => {
-      const takeaway = takeawayFaker({ topic_id: this.topic._id });
+    it( 'should create takeaway with valid topic', async() => {
+      const takeaway = takeawayFaker({
+        topic_id: this.topic._id,
+        owner_id: this.user.user._id
+      });
 
       const res = await client.post( path, takeaway );
 


### PR DESCRIPTION
### Context
We want to use the `owner_id` associated with objects for our permissions system. In order to do this, we will need to make sure that the `owner_id` is present on the `meeting`, `takeaway`, and `topic` models. We also don’t want to trust that a payload has the correct `owner_id` within it. Instead we can use the `sub` (stands for subject) prop present on our JWTs which is the `user._id`.  When we have participant authentication setup this property will be the `participant._id.`

### Implementation
  - Our create methods were already taking in a user ID from the request body (except topics). I switched this to pulling it from the request credentials.
  - Added owner_id to topic faker
  - Adjusted `saveMeetingTopics` to take in an `owner_id`

### Related Tickets:
  - [Notion](https://www.notion.so/thomashudsonnotes/Utilize-owner_id-for-objects-49207e9e76114bd8a658653ffe1e6f8d)
  - [Github Issue](https://github.com/SocexSolutions/agenda-v2/issues/209)


### Merge Checklist
- [x] Correct Target Branch
- [x] Pre-Review Diff Check
- [x] PR Description
- [x] Add Reviewers and Assignees
- [ ] Review Complete
- [ ] Rebase
- [ ] Rebase Approved
