### PR TITLE
Add takeaway update and takeaway permissions.

### DIFF
--- a/api/lib/controllers/takeaway.js
+++ b/api/lib/controllers/takeaway.js
@@ -1,32 +1,69 @@
+const log      = require('@starryinternet/jobi');
 const Takeaway = require('../models/takeaway');
 
 module.exports = {
   create: async( req, res ) => {
     try {
-      const { content, topic_id } = req.body;
-      const owner_id = req.credentials.sub;
+      const { name, description, topic_id } = req.body;
+      const subject_id = req.credentials.sub;
 
       const takeaway = await Takeaway.create({
-        content,
+        name,
+        description,
         topic_id,
-        owner_id
+        owner_id: subject_id
       });
 
       res.status( 201 ).send( takeaway );
     } catch ( err ) {
+      log.error( err );
+      res.status( 500 ).send( err );
+    }
+  },
+
+  update: async( req, res ) => {
+    try {
+      const { id } = req.params;
+      const { name, description } = req.body;
+      const subject_id = req.credentials.sub;
+
+      const takeaway = await Takeaway.findOne({ _id: id });
+
+      if ( subject_id !== takeaway.owner_id.toString() ) {
+        return res.status( 403 ).send('unauthorized');
+      }
+
+      const updatedTakeaway = await Takeaway.findOneAndUpdate(
+        { _id: id },
+        { name, owner_id: subject_id, description  },
+        { new: true }
+      );
+
+      res.status( 200 ).send( updatedTakeaway );
+    } catch ( err ) {
+      log.error( err );
       res.status( 500 ).send( err );
     }
   },
 
   delete: async( req, res ) => {
     try {
-      const res2 = await Takeaway.deleteOne({
-        _id: req.params.id
+      const { id } = req.params;
+      const subject_id = req.credentials.sub;
+
+      const takeaway = await Takeaway.findOne({ _id: id });
+
+      if ( subject_id !== takeaway.owner_id.toString() ) {
+        return res.status( 403 ).send('unauthorized');
+      }
+
+      const deleted = await Takeaway.deleteOne({
+        _id: id
       });
 
-      res.status( 200 ).send( res2 );
+      res.status( 200 ).send( deleted );
     } catch ( err ) {
-      console.log( err );
+      log.error( err );
       res.status( 500 ).send( err );
     }
   }

--- a/api/lib/models/takeaway.js
+++ b/api/lib/models/takeaway.js
@@ -2,7 +2,11 @@ const mongoose = require('mongoose');
 const Schema   = mongoose.Schema;
 
 const takeawaySchema = new Schema({
-  content: {
+  name: {
+    type: String,
+    required: true
+  },
+  description: {
     type: String,
     required: true
   },

--- a/api/lib/routes/takeaway.js
+++ b/api/lib/routes/takeaway.js
@@ -2,6 +2,7 @@ const router             = require('express').Router();
 const takeawayController = require('../controllers/takeaway');
 
 router.post( '/', takeawayController.create );
+router.patch( '/:id', takeawayController.update );
 router.delete( '/:id', takeawayController.delete );
 
 module.exports = router;

--- a/api/test/fakes/meeting.js
+++ b/api/test/fakes/meeting.js
@@ -1,10 +1,8 @@
-
-const faker    = require('faker');
 const ObjectId = require('mongoose').Types.ObjectId;
 
 const meeting = ( opts ) => {
   return {
-    name: faker.company.bs(),
+    name: 'meeting about something',
     owner_id: new ObjectId,
     date: new Date(),
     ...opts

--- a/api/test/fakes/takeaway.js
+++ b/api/test/fakes/takeaway.js
@@ -1,4 +1,3 @@
-const faker    = require('faker');
 const ObjectId = require('mongoose').Types.ObjectId;
 
 const takeaway = ( overrides ) => {
@@ -6,7 +5,8 @@ const takeaway = ( overrides ) => {
   const owner_id = new ObjectId();
 
   return {
-    content: faker.random.words( Math.floor( Math.random() * 20 ) ),
+    name: 'we need to do something',
+    description: 'we need to do something and we need to do it now',
     reactions: [],
     topic_id: topic_id.toString(),
     owner_id: owner_id.toString(),

--- a/api/test/fakes/topic.js
+++ b/api/test/fakes/topic.js
@@ -1,10 +1,9 @@
-const faker    = require('faker');
 const ObjectId = require('mongoose').Types.ObjectId;
 
 const topic = ( opts ) => {
   return {
-    name: faker.commerce.productName(),
-    description: faker.company.bs(),
+    name: 'some topic name',
+    description: 'some topic description',
     meeting_id: new ObjectId,
     owner_id: new ObjectId,
     likes: [ 'bryan@bacon.com' ],

--- a/api/test/tests/controllers/meeting.js
+++ b/api/test/tests/controllers/meeting.js
@@ -32,6 +32,7 @@ describe( 'controllers/meeting', () => {
   before( async() => {
     await api.start();
     await db.connect();
+    await dbUtils.clean();
 
     const res = await client.post(
       '/user/register',

--- a/api/test/tests/controllers/participant.js
+++ b/api/test/tests/controllers/participant.js
@@ -25,9 +25,11 @@ const participant = {
 };
 
 describe( 'controllers/participant', () => {
+
   before( async() => {
     await api.start();
     await db.connect();
+    await dbUtils.clean();
 
     const res = await client.post(
       '/user/register',

--- a/api/test/tests/controllers/ui.js
+++ b/api/test/tests/controllers/ui.js
@@ -14,6 +14,7 @@ describe( 'controllers/ui', () => {
   before( async() => {
     await api.start();
     await db.connect();
+    await dbUtils.clean();
 
     const res = await client.post(
       '/user/register',

--- a/api/test/tests/controllers/user.js
+++ b/api/test/tests/controllers/user.js
@@ -20,6 +20,7 @@ describe( 'api/lib/controllers/user.js', () => {
   before( async() => {
     await api.start();
     await db.connect();
+    await dbUtils.clean();
   });
 
   beforeEach( async() => {

--- a/api/test/tests/models/topic.js
+++ b/api/test/tests/models/topic.js
@@ -14,6 +14,7 @@ describe( 'lib/models/topic', () => {
 
   before( async() => {
     await db.connect();
+    await dbUtils.clean();
   });
 
   beforeEach( async() => {


### PR DESCRIPTION
### Context

Another part of the permissions epic, owner challenges for takeaways.

### Implementation

Added a takeaway `update` route, owner checks for `update` and `delete`, and removed `faker` since it was [unleashing the Zalgo](https://bluepnume.medium.com/intentionally-unleashing-zalgo-with-promises-ab3f63ead2fd) which caused tests to be indeterminate.