### PR TITLE
Zb/meet takeaways

### DIFF
--- a/api/lib/controllers/takeaway.js
+++ b/api/lib/controllers/takeaway.js
@@ -3,6 +3,7 @@ const Takeaway = require('../models/takeaway');
 
 module.exports = {
   create: async( req, res ) => {
+    console.log('is this working');
     try {
       const { name, description, topic_id } = req.body;
       const subject_id = req.credentials.sub;

--- a/api/lib/controllers/takeaway.js
+++ b/api/lib/controllers/takeaway.js
@@ -3,7 +3,6 @@ const Takeaway = require('../models/takeaway');
 
 module.exports = {
   create: async( req, res ) => {
-    console.log('is this working');
     try {
       const { name, description, topic_id } = req.body;
       const subject_id = req.credentials.sub;

--- a/api/lib/controllers/topic.js
+++ b/api/lib/controllers/topic.js
@@ -1,5 +1,6 @@
-const log   = require('@starryinternet/jobi');
-const Topic = require('../models/topic');
+const log      = require('@starryinternet/jobi');
+const Topic    = require('../models/topic');
+const Takeaway = require('../models/takeaway');
 
 module.exports = {
   create: async( req, res ) => {
@@ -87,6 +88,21 @@ module.exports = {
       response.status( 200 ).send( res );
     } catch ( err ) {
       response.status( 500 ).send( err );
+    }
+  },
+
+  getTakeaways: async( req, res ) => {
+    try {
+      const  topic_id = req.params.id;
+
+      const takeaways = await Takeaway.find({ topic_id });
+
+      console.log( takeaways );
+
+      res.status( 200 ).send( takeaways );
+    } catch ( err ) {
+      log.error( err );
+      res.status( 500 ).send( err );
     }
   }
 };

--- a/api/lib/routes/topic.js
+++ b/api/lib/routes/topic.js
@@ -5,5 +5,6 @@ router.post( '/', topicController.create );
 router.post( '/:_id', topicController.update );
 router.patch( '/:_id/like', topicController.like );
 router.patch( '/:_id/status', topicController.status );
+router.get( '/:id/takeaways', topicController.getTakeaways );
 
 module.exports = router;

--- a/api/test/tests/controllers/topic.js
+++ b/api/test/tests/controllers/topic.js
@@ -1,10 +1,11 @@
-const { assert } = require('chai');
-const dbUtils    = require('../../utils/db');
-const db         = require('../../../lib/db');
-const api        = require('../../utils/api');
-const client     = require('../../utils/client');
-const Topic      = require('../../../lib/models/topic');
-const topicFaker = require('../../fakes/topic');
+const { assert }    = require('chai');
+const dbUtils       = require('../../utils/db');
+const db            = require('../../../lib/db');
+const api           = require('../../utils/api');
+const client        = require('../../utils/client');
+const Topic         = require('../../../lib/models/topic');
+const topicFaker    = require('../../fakes/topic');
+const takeawayFaker = require('../../fakes/takeaway');
 
 describe( 'api/lib/controllers/topic', () => {
 
@@ -236,5 +237,36 @@ describe( 'api/lib/controllers/topic', () => {
       assert.strictEqual( topic.name, this.topic.name );
     });
   });
+
+  describe( '#getTakeaways', () => {
+    const path = '/takeaway';
+
+    it( 'should get topic\'s takeaways', async() => {
+      const topic = topicFaker();
+
+      const res = await client.post( '/topic', topic );
+
+      const takeaway = takeawayFaker({
+        topic_id: res.data._id,
+        owner_id: user.user._id
+      });
+
+      const res2 = await client.post( path, takeaway );
+
+      const { data } = await client.get(
+        '/topic/' + res.data._id + '/takeaways'
+      );
+
+      console.log( res.data );
+
+      assert.containSubset(
+        data[ 0 ], res2.data
+      );
+    });
+
+
+
+  });
+
 
 });

--- a/www/components/Bundles/Meeting/DiscussionForm.js
+++ b/www/components/Bundles/Meeting/DiscussionForm.js
@@ -1,7 +1,7 @@
 import styles from '../../../styles/Bundles/Meeting/DiscussionForm.module.css';
 import Input from '../../../components/Input.js';
 import Button from '../../../components/Button.js';
-import saveTakeaway from '../../../store/features/takeaway/takeawaySlice';
+import { saveTakeaway } from '../../../store/features/takeaway/takeawaySlice';
 import { notify } from '../../../store/features/snackbar/snackbarSlice';
 
 import { useEffect, useState } from 'react';
@@ -18,13 +18,15 @@ const DiscussionForm = ( props ) => {
       try {
         await props.store.dispatch(
           saveTakeaway({
-            title: props.takeawayTitle,
-            description: props.takeawayDescription,
-            topicId: props.topicId
+            title: takeawayTitle,
+            description: takeawayDescription,
+            _id: props.topicId
           })
         );
 
-
+        setTakeawayTitle('');
+        setTakeawayDescription('');
+        setSaving( false );
       } catch ( err ) {
         props.store.dispatch(
           notify({
@@ -39,22 +41,14 @@ const DiscussionForm = ( props ) => {
     if ( saving ) {
       save();
     }
-
-    setSaving( false );
   }, [ saving ] );
 
   function handleEnter( e ) {
-    if ( e.key === 'Enter' && e.target.value ) {
-      addTakeaway( e.target.value );
-      setTakeawayTitle('');
-      setTakeawayDescription('');
-    }
+    if ( e.key === 'Enter' && e.target.value ) {}
   }
 
-  function handleSubmit( e ) {
+  function handleSubmit() {
     if ( takeawayTitle ) {
-      setTakeawayTitle('');
-      setTakeawayDescription('');
       setSaving( true );
     }
   }

--- a/www/components/Bundles/Meeting/DiscussionForm.js
+++ b/www/components/Bundles/Meeting/DiscussionForm.js
@@ -1,44 +1,98 @@
 import styles from '../../../styles/Bundles/Meeting/DiscussionForm.module.css';
 import Input from '../../../components/Input.js';
 import Button from '../../../components/Button.js';
+import saveTakeaway from '../../../store/features/takeaway/takeawaySlice';
+import { notify } from '../../../store/features/snackbar/snackbarSlice';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
-const DiscussionForm = ({ title, finish, addTakeaway }) => {
-  const [ takeaway, setTakeaway ] = useState('');
+const DiscussionForm = ( props ) => {
+
+  const [ takeawayTitle, setTakeawayTitle ] = useState('');
+  const [ takeawayDescription, setTakeawayDescription ] = useState('');
+  const [ showInput, setShowInput ] = useState( false );
+  const [ saving, setSaving ] = useState( false );
+
+  useEffect( () => {
+    const save = async() => {
+      try {
+        await props.store.dispatch(
+          saveTakeaway({
+            title: props.takeawayTitle,
+            description: props.takeawayDescription,
+            topicId: props.topicId
+          })
+        );
+
+
+      } catch ( err ) {
+        props.store.dispatch(
+          notify({
+            message: 'Add Takeaway Failed: ' + err.message,
+            type: 'danger',
+            success: false
+          })
+        );
+      }
+    };
+
+    if ( saving ) {
+      save();
+    }
+
+    setSaving( false );
+  }, [ saving ] );
 
   function handleEnter( e ) {
     if ( e.key === 'Enter' && e.target.value ) {
       addTakeaway( e.target.value );
-      setTakeaway('');
+      setTakeawayTitle('');
+      setTakeawayDescription('');
     }
   }
 
   function handleSubmit( e ) {
-    if ( takeaway ) {
-      addTakeaway( takeaway );
-      setTakeaway('');
+    if ( takeawayTitle ) {
+      setTakeawayTitle('');
+      setTakeawayDescription('');
+      setSaving( true );
     }
   }
 
   return (
     <>
       <div className={styles.container}>
-        <div className={styles.title}>{title}</div>
+        <div className={styles.title}>{props.title}</div>
         <Button
           text="Finish"
-          onClick={finish}
+          onClick={props.finish}
         />
       </div>
+      {!showInput &&
+      <Button text='Add Takeaway' onClick={() => setShowInput( !showInput )}/>
+      }
       <div className={styles.inputContainer}>
-        <Input
-          value={takeaway}
-          variant='outlined'
-          onChange={ ( e ) => setTakeaway( e.target.value )}
-          onKeyPress={ ( e ) => handleEnter( e )}
-          size='xl'
-        />
-        <Button text="Submit" />
+        { showInput &&
+        <div className={styles.container}>
+          <Input
+            value={takeawayTitle}
+            onChange={ ( e ) => setTakeawayTitle( e.target.value )}
+            onKeyPress={ ( e ) => handleEnter( e )}
+            size='large'
+          />
+          <Input
+            value={takeawayDescription}
+            variant='outlined'
+            size='xl'
+            onChange={ ( e ) => setTakeawayDescription( e.target.value )}
+            onKeyPress={ ( e ) => handleEnter( e )}
+            multiLine={true}
+            rows='4'
+            cols='50'
+          />
+          <Button text="Submit" onClick={( e ) => handleSubmit( e )}/>
+        </div>
+        }
       </div>
     </>
   );

--- a/www/components/Bundles/Meeting/DiscussionForm.js
+++ b/www/components/Bundles/Meeting/DiscussionForm.js
@@ -18,9 +18,9 @@ const DiscussionForm = ( props ) => {
       try {
         await props.store.dispatch(
           saveTakeaway({
-            title: takeawayTitle,
+            name: takeawayTitle,
             description: takeawayDescription,
-            _id: props.topicId
+            topic_id: props.topicId
           })
         );
 

--- a/www/pages/meeting/[id]/meet.js
+++ b/www/pages/meeting/[id]/meet.js
@@ -36,8 +36,11 @@ const Meet = ( props ) => {
           })
         });
 
+
         setLoading( false );
       }
+
+
     };
 
     loadMeeting();
@@ -53,8 +56,14 @@ const Meet = ( props ) => {
     }
   });
 
-  const addTakeaway = ( takeaway ) => {
+  const addTakeaway = ( takeawayTitle, takeawayDescription ) => {
+    const takeaway = {
+      name: takeawayTitle,
+      description: takeawayDescription
+    };
+
     setTakeaways([ ...takeaways, takeaway ]);
+    console.log( takeaway );
   };
 
   if ( loading ) {
@@ -93,10 +102,12 @@ const Meet = ( props ) => {
   const discussionForm = <DiscussionForm
     title={sorted[ splitIndex ].name}
     addTakeaway={addTakeaway}
+    topicId={sorted[ splitIndex ]._id}
+    store={props.store}
   />;
 
   const takeawayCards = takeaways.map( chip =>
-    <div className={sharedStyles.card} key={chip}>{chip}</div>
+    <div className={sharedStyles.card} key={chip}><h3>{chip.name}</h3><p>{chip.description}</p></div>
   );
 
   return (

--- a/www/pages/meeting/[id]/meet.js
+++ b/www/pages/meeting/[id]/meet.js
@@ -107,7 +107,10 @@ const Meet = ( props ) => {
   />;
 
   const takeawayCards = takeaways.map( chip =>
-    <div className={sharedStyles.card} key={chip}><h3>{chip.name}</h3><p>{chip.description}</p></div>
+    <div className={sharedStyles.card} key={chip}>
+      <h3>{chip.name}</h3>
+      <p>{chip.description}</p>
+    </div>
   );
 
   return (

--- a/www/store/features/takeaway/takeawaySlice.js
+++ b/www/store/features/takeaway/takeawaySlice.js
@@ -22,15 +22,23 @@ export const saveTakeaway = ( takeaway ) => {
   return async function takeawaySave( dispatch, getState ) {
     console.log('hi');
     try {
-      const res = await client.post(
+      const { data } = await client.post(
         'takeaway',
         takeaway
+      );
+
+      const takeaways = data.reduce(
+        ( prev, cur ) => {
+          prev[ cur._id ] = cur;
+          return prev;
+        },
+        {}
       );
 
       dispatch({
         type: 'takeaway/save',
         payload: {
-          takeaway
+          takeaways
         }
       });
     } catch ( error ) {

--- a/www/store/features/takeaway/takeawaySlice.js
+++ b/www/store/features/takeaway/takeawaySlice.js
@@ -1,0 +1,36 @@
+import client from '../../client';
+
+const initialState = {
+  takeaway: {}
+};
+
+const reducer = ( state = initialState, action ) => {
+
+  switch ( action.type ) {
+
+    case 'takeaway/save':
+      return { ...state, takeaway: action.payload };
+
+    default:
+      return state;
+  }
+};
+
+export const saveTakeaway = ( takeaway ) => {
+  return async function TakeawaySave( dispatch, getState ) {
+    await client.post(
+      'takeaway',
+      takeaway
+    );
+
+    dispatch({
+      type: 'takeaway/save',
+      payload: {
+        takeaway
+      }
+    });
+
+  };
+};
+
+export default reducer;

--- a/www/store/features/takeaway/takeawaySlice.js
+++ b/www/store/features/takeaway/takeawaySlice.js
@@ -6,6 +6,8 @@ const initialState = {
 
 const reducer = ( state = initialState, action ) => {
 
+  console.log( action );
+
   switch ( action.type ) {
 
     case 'takeaway/save':
@@ -17,19 +19,23 @@ const reducer = ( state = initialState, action ) => {
 };
 
 export const saveTakeaway = ( takeaway ) => {
-  return async function TakeawaySave( dispatch, getState ) {
-    await client.post(
-      'takeaway',
-      takeaway
-    );
-
-    dispatch({
-      type: 'takeaway/save',
-      payload: {
+  return async function takeawaySave( dispatch, getState ) {
+    console.log('hi');
+    try {
+      const res = await client.post(
+        'takeaway',
         takeaway
-      }
-    });
+      );
 
+      dispatch({
+        type: 'takeaway/save',
+        payload: {
+          takeaway
+        }
+      });
+    } catch ( error ) {
+      console.log( error );
+    }
   };
 };
 

--- a/www/store/rootReducer.js
+++ b/www/store/rootReducer.js
@@ -5,13 +5,15 @@ import meetingReducer  from './features/meetings/meetingSlice';
 import themeReducer    from './features/theme/themeSlice';
 import drawerReducer   from './features/drawer/drawerSlice';
 import snackbarReducer from './features/snackbar/snackbarSlice';
+import takeawayReducer from './features/takeaway/takeawaySlice';
 
 const rootReducer = combineReducers({
   user:     userReducer,
   meetings: meetingReducer,
   theme:    themeReducer,
   drawer:   drawerReducer,
-  snackbar: snackbarReducer
+  snackbar: snackbarReducer,
+  takeaway: takeawayReducer
 });
 
 export default rootReducer;

--- a/www/styles/Bundles/Meeting/DiscussionForm.module.css
+++ b/www/styles/Bundles/Meeting/DiscussionForm.module.css
@@ -9,6 +9,10 @@
   padding: 5px;
 }
 
+.container Input {
+  margin-bottom: 1rem;
+}
+
 .inputContainer {
  display: flex;
   flex-direction: row;

--- a/www/styles/Shared.module.css
+++ b/www/styles/Shared.module.css
@@ -13,6 +13,20 @@
   font-weight: 600;
 }
 
+/* Styles for takeaway cards: */
+
+.card h3 {
+  text-align: left;
+  padding-left: 1rem;
+}
+
+.card p {
+  text-align: left;
+  font-weight: 100;
+  font-size: small;
+  padding-left: 1rem;
+}
+
 @media only screen and (max-width: 600px) {
   .card {
     min-width: 90px;


### PR DESCRIPTION
PR writeup by @thudsonbu 

### Context
One of the primary functions of the `meet` page is to allow users to add takeaways to topics. For now we just want to meeting owner to be able to add a takeaway. For the current topic that is under discussion.

### Implementation
The `takeaway-form` will take in a topic’s `_id` and any existing takeaways for that topic if any as props. It will be placed in the center column of the meeting `meet` page and as topics are added it will add them to a list extending down the page. The form will not have an input immediately. Instead there will be an add button below the card with the topic’s description. When the add button is clicked it will open a new takeaway card/form for the user to fill in takeaway info. This card will look very similar to the existing topic card on the `meeting/id` page. When the user hits save, the `takeaway` will be saved to the database in the background, showing up as saved immediately.


### Preview 
![image](https://user-images.githubusercontent.com/80174782/165671115-e1587491-96ab-4576-a98c-6a5237bd0fae.png)

### Merge Checklist
- [x] Correct Target Branch
- [x] Pre-Review Diff Check
- [x] PR Description
- [x] Add Reviewers and Assignees
- [ ] Review Complete
- [ ] Rebase
- [ ] Rebase Approved
