### PR TITLE
Zb/th/takeaways remastered

### DIFF
--- a/api/lib/controllers/topic.js
+++ b/api/lib/controllers/topic.js
@@ -1,5 +1,6 @@
-const log   = require('@starryinternet/jobi');
-const Topic = require('../models/topic');
+const log      = require('@starryinternet/jobi');
+const Topic    = require('../models/topic');
+const Takeaway = require('../models/takeaway');
 
 module.exports = {
   create: async( req, res ) => {
@@ -87,6 +88,19 @@ module.exports = {
       response.status( 200 ).send( res );
     } catch ( err ) {
       response.status( 500 ).send( err );
+    }
+  },
+
+  getTakeaways: async( req, res ) => {
+    try {
+      const  topic_id = req.params.id;
+
+      const takeaways = await Takeaway.find({ topic_id });
+
+      res.status( 200 ).send( takeaways );
+    } catch ( err ) {
+      log.error( err );
+      res.status( 500 ).send( err );
     }
   }
 };

--- a/api/lib/models/takeaway.js
+++ b/api/lib/models/takeaway.js
@@ -3,12 +3,10 @@ const Schema   = mongoose.Schema;
 
 const takeawaySchema = new Schema({
   name: {
-    type: String,
-    required: true
+    type: String
   },
   description: {
-    type: String,
-    required: true
+    type: String
   },
   topic_id: {
     type: Schema.Types.ObjectId, ref: 'Topic',

--- a/api/lib/routes/topic.js
+++ b/api/lib/routes/topic.js
@@ -5,5 +5,6 @@ router.post( '/', topicController.create );
 router.post( '/:_id', topicController.update );
 router.patch( '/:_id/like', topicController.like );
 router.patch( '/:_id/status', topicController.status );
+router.get( '/:id/takeaways', topicController.getTakeaways );
 
 module.exports = router;

--- a/api/test/tests/controllers/topic.js
+++ b/api/test/tests/controllers/topic.js
@@ -1,10 +1,12 @@
-const { assert } = require('chai');
-const dbUtils    = require('../../utils/db');
-const db         = require('../../../lib/db');
-const api        = require('../../utils/api');
-const client     = require('../../utils/client');
-const Topic      = require('../../../lib/models/topic');
-const topicFaker = require('../../fakes/topic');
+const { assert }    = require('chai');
+const dbUtils       = require('../../utils/db');
+const db            = require('../../../lib/db');
+const api           = require('../../utils/api');
+const client        = require('../../utils/client');
+const Topic         = require('../../../lib/models/topic');
+const Takeaway      = require('../../../lib/models/takeaway');
+const topicFaker    = require('../../fakes/topic');
+const takeawayFaker = require('../../fakes/takeaway');
 
 describe( 'api/lib/controllers/topic', () => {
 
@@ -235,6 +237,32 @@ describe( 'api/lib/controllers/topic', () => {
       assert.strictEqual( topic.status, 'discussed' );
       assert.strictEqual( topic.name, this.topic.name );
     });
+  });
+
+  describe( '#getTakeaways', () => {
+
+    it( 'should get topic\'s takeaways', async() => {
+      const topic = topicFaker();
+
+      const insertedTopic = await Topic.create( topic );
+
+      const takeaway = takeawayFaker({
+        topic_id: insertedTopic._id.toString(),
+        owner_id: user.user._id
+      });
+
+      await Takeaway.create( takeaway );
+
+      const { data: [ foundTakeaway ] } = await client.get(
+        '/topic/' + insertedTopic._id + '/takeaways'
+      );
+
+      assert.strictEqual( takeaway.name, foundTakeaway.name );
+      assert.strictEqual( takeaway.description, foundTakeaway.description );
+      assert.strictEqual( takeaway.topic_id, foundTakeaway.topic_id );
+      assert.strictEqual( takeaway.owner_id, foundTakeaway.owner_id );
+    });
+
   });
 
 });

--- a/www/components/Bundles/Meeting/DiscussionForm.js
+++ b/www/components/Bundles/Meeting/DiscussionForm.js
@@ -1,47 +1,136 @@
 import styles from '../../../styles/Bundles/Meeting/DiscussionForm.module.css';
-import Input from '../../../components/Input.js';
+import Card from '../../Card';
 import Button from '../../../components/Button.js';
+import AddIcon from '@mui/icons-material/Add';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
-const DiscussionForm = ({ title, finish, addTakeaway }) => {
-  const [ takeaway, setTakeaway ] = useState('');
+import client from '../../../store/client';
 
-  function handleEnter( e ) {
-    if ( e.key === 'Enter' && e.target.value ) {
-      addTakeaway( e.target.value );
-      setTakeaway('');
+const TakeawayForm = ( props ) => {
+  const [ loading, setLoading ]     = useState( true );
+  const [ deleting, setDeleting ]   = useState('');
+  const [ saving, setSaving ]       = useState( null );
+  const [ creating, setCreating ]   = useState( false );
+  const [ takeaways, setTakeaways ] = useState([]);
+  const [ editingId, setEditingId ] = useState('');
+
+  useEffect( () => {
+    const fetchTakeaways = async() => {
+      const res = await client.get( `topic/${ props.topic_id }/takeaways` );
+
+      setTakeaways( res.data );
+      setLoading( false );
+    };
+
+    if ( loading ) {
+      fetchTakeaways();
     }
-  }
+  }, [ loading ] );
 
-  function handleSubmit( e ) {
-    if ( takeaway ) {
-      addTakeaway( takeaway );
-      setTakeaway('');
+  useEffect( () => {
+    const create = async() => {
+      const res = await client.post(
+        'takeaway',
+        {
+          name: '',
+          description: '',
+          topic_id: props.topic_id
+        }
+      );
+
+      setCreating( false );
+      setTakeaways([ ...takeaways, res.data ]);
+      setEditingId( res.data._id );
+    };
+
+    if ( creating ) {
+      create();
+    }
+  }, [ creating ] );
+
+  useEffect( () => {
+    const save = async() => {
+      await client.patch(
+        `takeaway/${ saving._id }`,
+        saving
+      );
+    };
+
+    if ( saving ) {
+      save();
+      setSaving( null );
+    }
+  }, [ saving ] );
+
+  useEffect( () => {
+    const deleteT = async() => {
+      await client.delete( `takeaway/${ deleting }` );
+      setLoading( true );
+    };
+
+    if ( deleting ) {
+      deleteT();
+      setDeleting('');
+    }
+  }, [ deleting ] );
+
+  const saveTakeaway = ( takeaway ) => {
+    setEditingId( null );
+    setSaving( takeaway );
+  };
+
+  const deleteTakeaway = ( _id ) => {
+    setDeleting( _id );
+  };
+
+  const createTakeaway = () => {
+    setCreating( true );
+  };
+
+  const takeawayCards = [];
+
+  if ( takeaways.length ) {
+    for ( const t of takeaways ) {
+      const editing = editingId === t._id;
+      if ( editing ) {
+        takeawayCards.push(
+          <Card
+            setEditing={setEditingId}
+            editing={ editingId === t._id }
+            key={t._id}
+            item={t}
+            saveTakeaway={saveTakeaway}
+            deleteTakeaway={deleteTakeaway}
+          />
+        );
+      } else {
+        takeawayCards.push(
+          <Card
+            setEditing={setEditingId}
+            key={t._id}
+            item={t}
+            saveTakeaway={saveTakeaway}
+            deleteTakeaway={deleteTakeaway}
+          />
+        );
+      }
     }
   }
 
   return (
     <>
-      <div className={styles.container}>
-        <div className={styles.title}>{title}</div>
+      <div className={styles.cardContainer}>
+        {takeawayCards}
         <Button
-          text="Finish"
-          onClick={finish}
+          onClick={() => createTakeaway()}
+          variant='icon'
+          text='New'
+          icon={<AddIcon />}
         />
-      </div>
-      <div className={styles.inputContainer}>
-        <Input
-          value={takeaway}
-          variant='outlined'
-          onChange={ ( e ) => setTakeaway( e.target.value )}
-          onKeyPress={ ( e ) => handleEnter( e )}
-          size='xl'
-        />
-        <Button text="Submit" />
       </div>
     </>
   );
 };
 
-export default DiscussionForm;
+export default TakeawayForm;

--- a/www/components/Button.js
+++ b/www/components/Button.js
@@ -4,7 +4,14 @@ import { useRef, useState } from 'react';
 import useClickAway from '../utils/clickAway';
 import styles from '../styles/Button.module.css';
 
-
+/**
+ * @param {Icon} icon - icon for the button
+ * @param {String} text - text to be displayed in button
+ * @param {String} size - size of button
+ * @param {Function} onClick - click handler
+ * @param {String} variant - button variant [outlined, disabled, menu, icon]
+ * @param {String} type - success or danger
+ */
 const Button = ({
   icon,
   text,

--- a/www/components/Card.js
+++ b/www/components/Card.js
@@ -1,0 +1,76 @@
+import styles from '../styles/Card.module.css';
+import PropTypes from 'prop-types';
+
+import Input from './Input';
+import Button from './Button';
+
+import { useState } from 'react';
+
+/**
+ * @param {Object} item             - item that to display
+ * @param {Function} saveTakeaway   - save function for an item
+ * @param {Function} deleteTakeaway - delete function (called with items _id)
+ */
+const Card = ({
+  editing,
+  setEditing,
+  item,
+  saveTakeaway,
+  deleteTakeaway
+}) => {
+  const [ name, setName ]               = useState( item.name || null );
+  const [ description, setDescription ] = useState( item.description || null );
+
+  const onSave = () => {
+    saveTakeaway({ ...item, name, description });
+  };
+
+  const onDelete = () => {
+    deleteTakeaway( item._id );
+  };
+
+  if ( !editing ) {
+    return (
+      <div
+        className={styles.container}
+        onDoubleClick={() => setEditing( item._id )}
+      >
+        <h1>{name}</h1>
+        <p>{description}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <Input onChange={( e ) => setName( e.target.value ) } value={name}/>
+      <Input
+        multiLine={true}
+        rows='5'
+        value={description}
+        variant='outlined'
+        onChange={( e ) => setDescription( e.target.value )}
+      />
+      <div className={styles.buttonContainer}>
+        <Button
+          onClick={() => onDelete()}
+          text="delete"
+          size="small"
+          type='danger'
+        />
+        <Button
+          onClick={() => onSave()}
+          text="save"
+          size="small"
+          type='success'
+        />
+      </div>
+    </div>
+  );
+};
+
+Card.propTypes = {
+  saveTakeaway: PropTypes.func
+};
+
+export default Card;

--- a/www/pages/meeting/[id]/meet.js
+++ b/www/pages/meeting/[id]/meet.js
@@ -10,7 +10,6 @@ import styles       from '../../../styles/Meet.module.css';
 import sharedStyles from '../../../styles/Shared.module.css';
 
 const Meet = ( props ) => {
-  const [ takeaways, setTakeaways ]     = useState([]);
   const [ loading, setLoading ]         = useState( true );
   const [ meeting, setMeeting ]         = useState( null );
   const [ savingTopic, setSavingTopic ] = useState( false );
@@ -53,10 +52,6 @@ const Meet = ( props ) => {
     }
   });
 
-  const addTakeaway = ( takeaway ) => {
-    setTakeaways([ ...takeaways, takeaway ]);
-  };
-
   if ( loading ) {
     return (
       <div className={styles.loadingContainer}>
@@ -91,13 +86,8 @@ const Meet = ( props ) => {
   });
 
   const discussionForm = <DiscussionForm
-    title={sorted[ splitIndex ].name}
-    addTakeaway={addTakeaway}
+    topic_id={sorted[ splitIndex ]._id}
   />;
-
-  const takeawayCards = takeaways.map( chip =>
-    <div className={sharedStyles.card} key={chip}>{chip}</div>
-  );
 
   return (
     <div className={styles.container}>
@@ -105,8 +95,10 @@ const Meet = ( props ) => {
         { unDiscussedTopics }
       </div>
       <div className={styles.mainContainer}>
+        <div
+          style={{ border: '2px black dotted' }}
+        >{sorted[ splitIndex ].name}</div>
         { discussionForm }
-        { takeawayCards }
       </div>
       <div className={styles.sideContainer}>
         { discussedTopics }

--- a/www/styles/Bundles/Meeting/DiscussionForm.module.css
+++ b/www/styles/Bundles/Meeting/DiscussionForm.module.css
@@ -24,5 +24,9 @@
   border-radius: 10px;
   padding: 5px;
   min-height: 10rem;
-  overflow: scroll;
+}
+
+.cardContainer {
+  width: 90%;
+  margin-left: auto;
 }

--- a/www/styles/Card.module.css
+++ b/www/styles/Card.module.css
@@ -1,0 +1,41 @@
+.container {
+  font-size: 10px;
+  color: var(--agendaText);
+  background-color: var(--backgroundTwo);
+  border: 1px solid var(--agendaSecondary);
+  margin-bottom: 1rem;
+  padding: 1rem;
+  border-radius: 10px;
+  width: 90%;
+}
+
+.container h3 {
+  font-size: .9rem;
+  margin: 0;
+}
+
+.container input {
+  font-size: .9rem;
+  margin: .5rem 0rem;
+}
+
+.container textarea {
+  font-size: .75rem;
+  margin-top: .5rem;
+  width: 100%;
+}
+
+.container button {
+  margin-top: 1rem;
+  margin-left: auto;
+}
+
+.buttonContainer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.buttonContainer button {
+  margin-left: .25rem;
+  display: flex;
+}

--- a/www/styles/globals.css
+++ b/www/styles/globals.css
@@ -58,7 +58,7 @@ h3 {
 
 :root {
   --agenda: #244a93;
-  --agendaSecondary: #9dbeff;
+  --agendaSecondary: #578ffe;
   --agendaThree: #2254af ;
   --agendaText: #c6d7f6;
   --background: #082050;
@@ -75,7 +75,7 @@ h3 {
 
 [data-theme='default'] {
   --agenda: #244a93;
-  --agendaSecondary: #9dbeff;
+  --agendaSecondary: #578ffe;
   --agendaThree: #2254af ;
   --agendaText: #c6d7f6;
   --background: #082050;
@@ -105,4 +105,19 @@ h3 {
   --success: #9bc333;
   --successText: #dae8aa;
   --successBg: #5d8700;
+}
+
+/* use psuedoselector for scrollbar (not supported by all browsers) */
+body::-webkit-scrollbar {
+  width: 1rem;
+}
+
+body::-webkit-scrollbar-track {
+  background: var(--background);
+}
+
+/* thumb refers to the bar on the slider */
+body::-webkit-scrollbar-thumb {
+  background-image: linear-gradient(var(--agendaSecondary), var(--agendaSecondary));
+  border-radius: 25px;
 }


### PR DESCRIPTION
### Context
One of the primary functions of the meet page is to allow users to add takeaways to topics. For now we just want to meeting owner to be able to add a takeaway. For the current topic that is under discussion.

### Implementation
The takeaway-form will take in a topic’s _id and any existing takeaways for that topic if any as props. It will be placed in the center column of the meeting meet page and as topics are added it will add them to a list extending down the page. The form will not have an input immediately. Instead there will be an add button below the card with the topic’s description. When the add button is clicked it will open a new takeaway card/form for the user to fill in takeaway info. This card will look very similar to the existing topic card on the meeting/id page. When the user hits save, the takeaway will be saved to the database in the background, showing up as saved immediately.

<!--
### Feedback Request (optional)
Prose should include:
  - Are there any parts of the implementation you are unsure about?
  - Any obfuscated code?

You can also a add a comment directly to the pr.
-->

<!--
### Preview (optional)
Screen captures of changes if on frontend.
-->

```
             ,,,,,,,,
           ,|||````||||
     ,,,,|||||       ||,
  ,||||```````       `||
,|||`                 |||,
||`     ....,          `|||
||     ::::::::          |||,
||     :::::::'     ||    ``|||,
||,     :::::'               `|||
`||,                           |||
 `|||,       ||          ||    ,||
   `||                        |||`
    ||                   ,,,||||
    ||              ,||||||```
   ,||         ,,|||||`
  ,||`   ||   |||`
 |||`         ||
,||           ||
||`           ||
|||,         |||
 `|||,,    ,|||
   ``||||||||`
```

### Merge Checklist
- [x] Correct Target Branch
- [x] Pre-Review Diff Check
- [x] PR Description
- [x] Add Reviewers and Assignees
- [x] Review Complete
- [x] Rebase
- [x] Rebase Approved
