### PR TITLE
New Meeting Reroute

### DIFF
--- a/www/pages/meeting/[id]/index.js
+++ b/www/pages/meeting/[id]/index.js
@@ -70,7 +70,7 @@ const Meeting = ( props ) => {
       const real_id = meeting_id.length === 24;
 
       try {
-        await client.post(
+        const res = await client.post(
           'meeting/aggregate',
           {
             name,
@@ -89,6 +89,8 @@ const Meeting = ( props ) => {
             message: 'Save Successful'
           })
         );
+
+        if ( !real_id ) { router.push( `/meeting/${ res.data._id }` ); }
       } catch ( err ) {
         setSaving( false );
         props.store.dispatch(


### PR DESCRIPTION
### Context
When creating a new meeting. Page would not reroute you to the created meeting. 

### Implementation
If a new meeting is being created then reroute to new meeting edit page after save


### Feedback Request
This implementation might be a little confusing for the user. Maybe we could add a back to inbox prompt?

<!--
### Preview (optional)
Screen captures of changes if on frontend.
-->

### Merge Checklist
- [x] Correct Target Branch
- [x] Pre-Review Diff Check
- [x] PR Description
- [x] Add Reviewers and Assignees
- [ ] Review Complete
- [ ] Rebase
- [ ] Rebase Approved
