### PR TITLE
No Topics Bug

### DIFF
--- a/www/pages/meeting/[id]/meet.js
+++ b/www/pages/meeting/[id]/meet.js
@@ -186,7 +186,7 @@ const Meet = ( props ) => {
     }
   }, [ closingTopic ] );
 
-  if ( !meeting || !topics.length ) {
+  if ( !meeting || topicsLoading ) {
     return (
       <div className={styles.loadingContainer}>
         <LoadingIcon />


### PR DESCRIPTION
### Context
If a meeting has no topics, the page would be stuck in an infinite cycle of loading. **We will want to handle meetings with no topics somehow when the owners goes to start the meeting. Like a prompt "Are you sure you want to start the meeting with no topics?" or maybe disallow it altogether.** 

### Implementation
Checking topic array length to display loading bar was breaking it. We already had topic loading state so I just used that instead.

### Merge Checklist
- [x] Correct Target Branch
- [x] Pre-Review Diff Check
- [x] PR Description
- [x] Add Reviewers and Assignees
- [ ] Review Complete
- [ ] Rebase
- [ ] Rebase Approved
