### PR TITLE
improved check_participant auth util

### DIFF
--- a/api/lib/auth/check-participant.js
+++ b/api/lib/auth/check-participant.js
@@ -1,14 +1,33 @@
 const Participant = require('../models/participant');
+const Meeting     = require('../models/meeting');
 
 /**
- * Check if a user is a participant of a meeting. Returns true if a user is a
- * participant, and false if they are not
+ * Check if a user is a participant or owner of a meeting
+ *
  * @param {ObjectId} meeting_id
- * @param {boolean} email
- * @returns {Promise<boolean>}
+ * @param {Object} user
+ *
+ * @typedef {Object} AuthorizationResult
+ * @property {Boolean} authorized - user is authorized
+ * @property {Meeting} meeting - meeting returned for utility
+ *
+ * @returns {Promise<AuthorizationResult>}
  */
-module.exports = async( meeting_id, email ) => {
-  const found = await Participant.findOne({ meeting_id, email });
+module.exports = async( meeting_id, user, res ) => {
+  const [ participant, meeting ] = await Promise.allSettled([
+    Participant.findOne({ meeting_id, email: user.email }),
+    Meeting.findOne({ _id: meeting_id })
+  ]);
 
-  return !!found;
+  const is_owner = meeting.status === 'fulfilled' &&
+    meeting.value.owner_id.toString() === user._id.toString();
+
+  const is_participant = participant.status === 'fulfilled' &&
+    participant.value;
+
+  if ( is_owner || is_participant ) {
+    return { authorized: true, meeting: meeting.value };
+  }
+
+  return { authorized: false, meeting: {} };
 };

--- a/api/lib/controllers/meeting.js
+++ b/api/lib/controllers/meeting.js
@@ -14,15 +14,12 @@ module.exports = {
    */
   get: async( req, res ) => {
     try {
-      const { _id }        = req.params;
-      const { sub, email } = req.credentials;
+      const { _id }  = req.params;
+      const { user } = req.credentials;
 
-      const meeting = await Meeting.findOne({ _id });
+      const { authorized, meeting } = await check_participant( _id, user );
 
-      const is_participant = await check_participant( _id, email );
-      const is_owner       = sub === meeting.owner_id.toString();
-
-      if ( !( is_participant || is_owner ) ) {
+      if ( !authorized ) {
         return res.status( 403 ).send('unauthorized');
       }
 
@@ -228,15 +225,12 @@ module.exports = {
 
   async getTopics( req, res ) {
     try {
-      const { _id }        = req.params;
-      const { sub, email } = req.credentials;
+      const { _id }  = req.params;
+      const { user } = req.credentials;
 
-      const meeting = await Meeting.findOne({ _id });
+      const { authorized } = await check_participant( _id, user );
 
-      const is_participant = await check_participant( _id, email );
-      const is_owner       = sub === meeting.owner_id.toString();
-
-      if ( !( is_participant || is_owner ) ) {
+      if ( !authorized ) {
         return res.status( 403 ).send('unauthorized');
       }
 
@@ -251,15 +245,12 @@ module.exports = {
 
   async getParticipants( req, res ) {
     try {
-      const { _id }        = req.params;
-      const { email, sub } = req.credentials;
+      const { _id }  = req.params;
+      const { user } = req.credentials;
 
-      const meeting = await Meeting.findOne({ _id });
+      const { authorized } = await check_participant( _id, user );
 
-      const is_participant = await check_participant( _id, email );
-      const is_owner       = sub === meeting.owner_id.toString();
-
-      if ( !( is_participant || is_owner ) ) {
+      if ( !authorized ) {
         return res.status( 403 ).send('unauthorized');
       }
 

--- a/api/lib/controllers/topic.js
+++ b/api/lib/controllers/topic.js
@@ -5,10 +5,10 @@ const Takeaway = require('../models/takeaway');
 module.exports = {
   create: async( req, res ) => {
     const newTopic = req.body;
-    const sub_id = req.credentials.sub;
+    const { user } = req.credentials;
 
     try {
-      const topic = await Topic.create({ ...newTopic, sub_id });
+      const topic = await Topic.create({ ...newTopic, owner_id: user._id });
 
       res.status( 201 ).send( topic );
     } catch ( error ) {

--- a/api/lib/controllers/ui.js
+++ b/api/lib/controllers/ui.js
@@ -1,5 +1,5 @@
-const log      = require('@starryinternet/jobi');
-const Ui       = require('../models/ui');
+const log = require('@starryinternet/jobi');
+const Ui  = require('../models/ui');
 
 module.exports = {
   get: async( req, res ) => {

--- a/api/lib/controllers/user.js
+++ b/api/lib/controllers/user.js
@@ -144,12 +144,11 @@ module.exports = {
 
   async getOwnedMeetings( req, res ) {
     try {
-      const { _id } = req.params;
+      const { user } = req.credentials;
 
-      const meetings = await Meeting.find({ owner_id: _id });
+      const meetings = await Meeting.find({ owner_id: user._id });
 
       res.status( 200 ).json( meetings );
-
     } catch ( error ) {
       res.status( 500 ).send( error );
     }
@@ -166,7 +165,9 @@ module.exports = {
           new Error('Username already exists')
         );
 
-      } else { res.status( 200 ).send(); }
+      } else {
+        res.status( 200 ).send();
+      }
 
     } catch ( err ) {
       log.error( err.message );
@@ -184,7 +185,9 @@ module.exports = {
           new Error('Email already exists')
         );
 
-      } else { res.status( 200 ).send(); }
+      } else {
+        res.status( 200 ).send();
+      }
 
     } catch ( err ) {
       log.error( err.message );

--- a/api/lib/middleware/authenticate.js
+++ b/api/lib/middleware/authenticate.js
@@ -21,9 +21,9 @@ const authenticate = async( req, res, next ) => {
       }
     );
 
-    const { email } = await User.findOne({ _id: decoded.sub });
+    const user = await User.findOne({ _id: decoded.sub });
 
-    req.credentials = { ...decoded, email };
+    req.credentials = { ...decoded, user };
 
     next();
 

--- a/api/test/fakes/user.js
+++ b/api/test/fakes/user.js
@@ -1,4 +1,3 @@
-
 module.exports = ( overrides ) => {
   return {
     email: 'brian@brian.com',

--- a/api/test/tests/controllers/topic.js
+++ b/api/test/tests/controllers/topic.js
@@ -40,6 +40,7 @@ describe( 'api/lib/controllers/topic', () => {
   });
 
   describe( '#create', () => {
+
     const path = '/topic';
 
     it( 'should create topic with valid inputs', async() => {

--- a/package.json
+++ b/package.json
@@ -41,9 +41,6 @@
     "api",
     "www"
   ],
-  "dependencies": {
-    "lodash": "^4.17.21"
-  },
   "nyc": {
     "include": "api/lib/**/*.js"
   }


### PR DESCRIPTION
### Context

This is just another step toward authorization for all of our API routes.

### Implementation

I modified the `check_participant` authorization utility to return an object containing `authorized` and the `meeting` that was checked against. This allows us not to duplicate requests for the same meeting. Additionally, the `authenticate` middleware now adds the `user` to `req.credentials` since we end up needing the `user.email` in the vast majority of scenarios. 

We might be able to move away from doing this if we switch away from participants containing the user's email and instead containing a `user._id`. This would make meeting creation more difficult since we might need to create non-registered users. I am still figuring out how that would work.