### PR TITLE
Indexes on meeting_id Field Level

### DIFF
--- a/api/lib/models/participant.js
+++ b/api/lib/models/participant.js
@@ -10,7 +10,8 @@ const participantSchema = new mongoose.Schema(
     meeting_id: {
       type: Schema.Types.ObjectId,
       ref: 'Meeting',
-      required: true
+      required: true,
+      index: true
     }
   },
   {

--- a/api/lib/models/takeaway.js
+++ b/api/lib/models/takeaway.js
@@ -10,7 +10,8 @@ const takeawaySchema = new Schema({
   },
   topic_id: {
     type: Schema.Types.ObjectId, ref: 'Topic',
-    required: true
+    required: true,
+    index: true
   },
   reactions: [ {
     type: String

--- a/api/lib/models/topic.js
+++ b/api/lib/models/topic.js
@@ -14,7 +14,8 @@ const topicSchema = new mongoose.Schema(
     },
     meeting_id: {
       type: Schema.Types.ObjectId, ref: 'Meeting',
-      required: true
+      required: true,
+      index: true
     },
     owner_id: {
       type: Schema.Types.ObjectId, ref: 'User',


### PR DESCRIPTION
### Context
Need indexes on frequently used query params

Refs:
[Best Practices](https://www.mongodb.com/blog/post/performance-best-practices-indexing)
[Mongoose doc](https://mongoosejs.com/docs/guide.html#indexes)
[MongoDB doc](https://www.mongodb.com/docs/manual/indexes/) (for index options)

### Implementation
Mongoose makes indexing easy. Just add `index: true` to the whatever schema field you want the index on and it will automatically create an index for that field. 

### Merge Checklist
- [x] Correct Target Branch
- [x] Pre-Review Diff Check
- [x] PR Description
- [x] Add Reviewers and Assignees
- [ ] Review Complete
- [ ] Rebase
- [ ] Rebase Approved
