### PR TITLE
feat(takeaways): add meeting._id to takeaways

### DIFF
--- a/api/lib/controllers/takeaway.js
+++ b/api/lib/controllers/takeaway.js
@@ -1,12 +1,9 @@
 const Takeaway  = require('../models/takeaway');
-const Topic     = require('../models/topic');
 const authUtils = require('../util/authorization');
 
 module.exports = {
   create: async( req, res ) => {
-    const { name, description, topic_id } = req.body;
-
-    const { meeting_id } = await Topic.findOne({ _id: topic_id });
+    const { name, description, topic_id, meeting_id } = req.body;
 
     await authUtils.checkParticipant( meeting_id, req.credentials );
 
@@ -14,6 +11,7 @@ module.exports = {
       name,
       description,
       topic_id,
+      meeting_id,
       owner_id: req.credentials.sub
     });
 

--- a/api/lib/models/takeaway.js
+++ b/api/lib/models/takeaway.js
@@ -20,6 +20,11 @@ const takeawaySchema = new Schema({
     type: Schema.Types.ObjectId,
     ref: 'User',
     required: true
+  },
+  meeting_id: {
+    type: Schema.Types.ObjectId,
+    ref: 'Meeting',
+    required: true
   }
 });
 

--- a/api/test/fakes/takeaway.js
+++ b/api/test/fakes/takeaway.js
@@ -1,8 +1,9 @@
 const ObjectId = require('mongoose').Types.ObjectId;
 
 const takeaway = ( overrides ) => {
-  const topic_id = new ObjectId();
-  const owner_id = new ObjectId();
+  const topic_id   = new ObjectId();
+  const owner_id   = new ObjectId();
+  const meeting_id = new ObjectId();
 
   return {
     name: 'we need to do something',
@@ -10,6 +11,7 @@ const takeaway = ( overrides ) => {
     reactions: [],
     topic_id: topic_id.toString(),
     owner_id: owner_id.toString(),
+    meeting_id: meeting_id.toString(),
     ...overrides
   };
 };

--- a/api/test/tests/controllers/takeway.js
+++ b/api/test/tests/controllers/takeway.js
@@ -52,7 +52,10 @@ describe( 'lib/controllers/takeaway', () => {
     const path = '/takeaway';
 
     it( 'should create takeaway if meeting owner', async() => {
-      const takeaway = fakeTakeaway({ topic_id: this.topic._id });
+      const takeaway = fakeTakeaway({
+        topic_id: this.topic._id,
+        meeting_id: this.meeting._id
+      });
 
       const res = await client.post( path, takeaway );
 
@@ -103,7 +106,8 @@ describe( 'lib/controllers/takeaway', () => {
         path,
         fakeTakeaway({
           topic_id: this.topic._id,
-          owner_id: this.user._id
+          owner_id: this.user._id,
+          meeting_id: this.meeting._id
         })
       ) ).data;
     });
@@ -155,7 +159,11 @@ describe( 'lib/controllers/takeaway', () => {
     const path = '/takeaway';
 
     it( 'should delete takeaway', async() => {
-      const takeaway = fakeTakeaway({ topic_id: this.topic._id });
+      const takeaway = fakeTakeaway({
+        topic_id: this.topic._id,
+        meeting_id: this.meeting._id
+      });
+
       const resTakeaway = await client.post( path, takeaway );
 
       const res = await client.delete( path + '/' + resTakeaway.data._id );
@@ -172,7 +180,11 @@ describe( 'lib/controllers/takeaway', () => {
     });
 
     it( 'should 403 if not takeaway owner', async() => {
-      const takeaway = fakeTakeaway({ topic_id: this.topic._id });
+      const takeaway = fakeTakeaway({
+        topic_id: this.topic._id,
+        meeting_id: this.meeting._id
+      });
+
       const resTakeaway = await client.post( path, takeaway );
 
       client.defaults.headers.common['Authorization'] = this.user2.token;

--- a/www/pages/meeting/[id]/meet.js
+++ b/www/pages/meeting/[id]/meet.js
@@ -251,6 +251,7 @@ const Meet = ( props ) => {
                 getAll={ () => topicAPI.getTakeaways( live._id )}
                 create={ ( payload ) => takeawayAPI.create({
                   topic_id: live._id,
+                  meeting_id: meeting._id,
                   ...payload
                 })}
                 update={ ( id, payload ) => takeawayAPI.update( id, payload ) }


### PR DESCRIPTION
Adding the meeting id to takeaways will make authorization simpler because we will not need to fetch the takeaway's related topic in order to get the meeting id which we need to check if the user is participant of a meeting.
