### PR TITLE
fix(www:client): make sure client origin is correct

### DIFF
--- a/www/api/client.js
+++ b/www/api/client.js
@@ -3,7 +3,7 @@ import { getCookie } from '../utils/cookie';
 
 const baseURL = process.env.NODE_ENV === 'development' ?
   'http://localhost:4000/api' :
-  'https://meetingminder.com/api';
+  'https://meetingminder.dev/api';
 
 const client = axios.create({
   baseURL,


### PR DESCRIPTION
I messed up the origin for the client originally. At least until we are rolling in dough we will be at meetingminder.dev.