### PR TITLE
feat(api): add support for takeaways and action items in meeting agg

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.7.0
         with:
-          mongodb-version: 4.4
+          mongodb-version: 6.0
 
       - run: npm run keygen
 


### PR DESCRIPTION
I was thinking about how checking off action items should actually work and realized that we might just want a meeting review page that reads more like well organized meeting notes. We will need everything for the meeting review page so this controller seems like the best way to do it.

Note: make sure that your local mongo is running version 6, otherwise the nested joins in this query will not work.