### PR TITLE
Tagged mongodb version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "4.0.0"
 services:
 
   mongodb:
-    image: mongo:latest
+    image: mongo:6.0
     container_name: agenda.mongo
     volumes:
       - mongodb-data:/data/db

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -13,7 +13,7 @@ if [ ! "$( docker ps -q -f name=mongo )" ]; then
 
     printf "\n creating new mongo container \n";
 
-    docker container run -d -p 27017:27017 --name=mongo mongo
+    docker container run -d -p 27017:27017 --name=mongo mongo:6.0
 
   fi
 


### PR DESCRIPTION
Docker [image]:latest tag does not actually pull latest image version

https://cloud.ibm.com/docs/Registry?topic=Registry-troubleshoot-docker-latest

Tagged at mongo 6.0