### PR TITLE
Make Meeting Edit Use Store and Fix History Button Errors

### DIFF
--- a/www/classes/meeting-api.js
+++ b/www/classes/meeting-api.js
@@ -39,6 +39,8 @@ class MeetingAPI extends RestAPI {
           type: "danger",
         })
       );
+
+      return null;
     }
   }
 
@@ -61,6 +63,8 @@ class MeetingAPI extends RestAPI {
           type: "danger",
         })
       );
+
+      return null;
     }
   }
 
@@ -83,6 +87,8 @@ class MeetingAPI extends RestAPI {
           type: "danger",
         })
       );
+
+      return null;
     }
   }
 
@@ -105,6 +111,8 @@ class MeetingAPI extends RestAPI {
           type: "danger",
         })
       );
+
+      return null;
     }
   }
 
@@ -128,6 +136,8 @@ class MeetingAPI extends RestAPI {
           type: "danger",
         })
       );
+
+      return null;
     }
   }
 
@@ -152,6 +162,8 @@ class MeetingAPI extends RestAPI {
           type: "danger",
         })
       );
+
+      return null;
     }
   }
 }

--- a/www/classes/rest-api.js
+++ b/www/classes/rest-api.js
@@ -46,6 +46,8 @@ class RestAPI {
           type: "danger",
         })
       );
+
+      return null;
     }
   }
 
@@ -68,6 +70,8 @@ class RestAPI {
           type: "danger",
         })
       );
+
+      return null;
     }
   }
 
@@ -92,7 +96,7 @@ class RestAPI {
         })
       );
 
-      return {};
+      return null;
     }
   }
 
@@ -106,6 +110,8 @@ class RestAPI {
   async destroy(id) {
     try {
       await client.delete(`${this.type}/${id}`);
+
+      return id;
     } catch (err) {
       store().dispatch(
         notify({
@@ -113,6 +119,8 @@ class RestAPI {
           type: "danger",
         })
       );
+
+      return null;
     }
   }
 }

--- a/www/classes/topic-api.js
+++ b/www/classes/topic-api.js
@@ -31,7 +31,7 @@ class TopicAPI extends RestAPI {
         })
       );
 
-      return [];
+      return null;
     }
   }
 
@@ -53,7 +53,7 @@ class TopicAPI extends RestAPI {
         })
       );
 
-      return [];
+      return null;
     }
   }
 
@@ -73,6 +73,8 @@ class TopicAPI extends RestAPI {
           type: "danger",
         })
       );
+
+      return null;
     }
   }
 
@@ -93,6 +95,8 @@ class TopicAPI extends RestAPI {
           type: "danger",
         })
       );
+
+      return null;
     }
   }
 
@@ -112,6 +116,8 @@ class TopicAPI extends RestAPI {
           type: "danger",
         })
       );
+
+      return null;
     }
   }
 }

--- a/www/components/shared/ChipForm/ChipForm.module.css
+++ b/www/components/shared/ChipForm/ChipForm.module.css
@@ -1,13 +1,5 @@
-.topics {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.topics >* {
-  margin-right: .5rem;
-}
-
-.chipContainer {
+.chip_container {
+  margin-top: 1em;
   display: flex;
   flex-direction: row;
   align-items: flex-start;
@@ -16,12 +8,16 @@
   min-height: 45px;
 }
 
-.inputContainer {
-  margin-top: 1rem;
+.chip {
+  margin-right: 5px;
+}
+
+.input_container {
+  margin-top: 0.5em;
   display: flex;
   align-items: flex-start;
 }
 
-.addButton {
-  margin-left: 1rem;
+.add_button {
+  margin-left: 1em;
 }

--- a/www/pages/meeting/[id]/edit.js
+++ b/www/pages/meeting/[id]/edit.js
@@ -3,6 +3,7 @@ import StatusButton from "../../../components/pages/Edit/StatusButton/StatusButt
 import CardBoard from "../../../components/shared/CardBoard/CardBoard";
 import ChipForm from "../../../components/shared/ChipForm/ChipForm";
 import CardForm from "../../../components/shared/CardForm/CardForm";
+import LoadingIcon from "../../../components/shared/LoadingIcon/LoadingIcon";
 
 import { Fade } from "@mui/material";
 
@@ -23,46 +24,55 @@ const Meeting = (props) => {
   const router = useRouter();
   const dispatch = useDispatch();
 
-  const user = useSelector((state) => state.user);
-
   const meeting_id = router.query.id;
 
-  const [initLoad, setInitLoad] = useState(true);
+  const meeting = useSelector((state) =>
+    meetingStore.selectors.get(state, meeting_id)
+  );
+
+  const [initialized, setInitialized] = useState(false);
   const [name, setName] = useState("");
   const [date, setDate] = useState("");
   const [status, setStatus] = useState("");
 
   useEffect(() => {
-    const loadMeeting = async () => {
-      const res = await meetingAPI.get(meeting_id);
-
-      setName(res.name);
-      setDate(res.date);
-      setStatus(res.status);
-
-      setInitLoad(false);
-    };
-
-    if (initLoad && meeting_id) {
-      loadMeeting();
+    if (!initialized && meeting_id) {
+      dispatch(meetingStore.actions.get(meeting_id));
+      setInitialized(true);
     }
-  }, [user, props.store, router.query.id]);
+
+    if (meeting) {
+      setName(meeting.name);
+      setDate(meeting.date);
+      setStatus(meeting.status);
+    }
+  }, [meeting, props.store, router.query.id]);
 
   const updateMeeting = ({ name, date }) => {
-    meetingAPI.update(meeting_id, { name, date });
+    dispatch(meetingStore.actions.update({ name, date, _id: meeting_id }));
 
     setName(name);
     setDate(date);
   };
 
   const updateMeetingStatus = ({ status }) => {
-    meetingAPI.updateStatus(meeting_id, status);
+    dispatch(meetingStore.actions.updateStatus(meeting_id, status));
 
     setStatus(status);
   };
 
+  const loading = !meeting || !meeting_id;
+
+  if (loading) {
+    return (
+      <div className={styles.blank_container}>
+        <LoadingIcon />
+      </div>
+    );
+  }
+
   return (
-    <Fade in={!initLoad}>
+    <Fade in={initialized}>
       <div className={shared.page}>
         <div className={styles.container}>
           <section className={styles.header}>

--- a/www/pages/meeting/[id]/edit.js
+++ b/www/pages/meeting/[id]/edit.js
@@ -7,11 +7,9 @@ import LoadingIcon from "../../../components/shared/LoadingIcon/LoadingIcon";
 
 import { Fade } from "@mui/material";
 
-import meetingAPI from "../../../api/meeting";
-import participantAPI from "../../../api/participant";
-
 import meetingStore from "../../../store/features/meeting";
 import topicStore from "../../../store/features/topic";
+import participantStore from "../../../store/features/participant";
 
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -96,17 +94,25 @@ const Meeting = (props) => {
           <section className={shared.card + " " + styles.section}>
             <h3>Participants</h3>
             <ChipForm
-              change={meeting_id}
+              selector={(state) =>
+                meetingStore.selectors.participants(state, meeting_id)
+              }
               itemKey={"email"}
               itemName={"participant"}
-              getAll={() => meetingAPI.getParticipants(meeting_id)}
-              create={(payload) =>
-                participantAPI.create({
-                  meeting_id,
-                  ...payload,
-                })
+              getAll={() =>
+                dispatch(meetingStore.actions.getParticipants(meeting_id))
               }
-              destroy={(id) => participantAPI.destroy(id)}
+              create={(item) =>
+                dispatch(
+                  participantStore.actions.create({
+                    meeting_id,
+                    ...item,
+                  })
+                )
+              }
+              destroy={(item) =>
+                dispatch(participantStore.actions.delete(item))
+              }
             />
           </section>
           <section

--- a/www/store/features/meeting.js
+++ b/www/store/features/meeting.js
@@ -2,6 +2,7 @@ import { createSlice } from "@reduxjs/toolkit";
 import { generateSlice } from "../utils/slice-generator";
 import { generateActions } from "../utils/slice-generator";
 import { generateSelectors } from "../utils/slice-generator";
+import meetingAPI from "../../api/meeting";
 
 const meetingSchema = {
   name: "meeting",
@@ -14,6 +15,22 @@ const meetingSchema = {
 
 export const { reducer } = createSlice(generateSlice(meetingSchema));
 export const actions = generateActions(meetingSchema);
+
+actions.updateStatus = (meeting_id, status) => {
+  return async (dispatch) => {
+    const updated = await meetingAPI.updateStatus(meeting_id, status);
+
+    if (!updated) {
+      return;
+    }
+
+    dispatch({
+      type: "meeting/update",
+      payload: { _id: meeting_id, status },
+    });
+  };
+};
+
 export const selectors = generateSelectors(meetingSchema);
 
 export default {

--- a/www/store/features/participant.js
+++ b/www/store/features/participant.js
@@ -1,0 +1,21 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { generateSlice } from "../utils/slice-generator";
+import { generateActions } from "../utils/slice-generator";
+import { generateSelectors } from "../utils/slice-generator";
+
+const participantSchema = {
+  name: "participant",
+  dependencies: {
+    meeting: "meeting_id",
+  },
+};
+
+export const { reducer } = createSlice(generateSlice(participantSchema));
+export const actions = generateActions(participantSchema);
+export const selectors = generateSelectors(participantSchema);
+
+export default {
+  actions,
+  reducer,
+  selectors,
+};

--- a/www/store/features/topic.js
+++ b/www/store/features/topic.js
@@ -23,6 +23,10 @@ actions.like = (topic) => {
   return async function like(dispatch) {
     const updatedTopic = await topicApi.like(topic._id);
 
+    if (!updatedTopic) {
+      return;
+    }
+
     dispatch({
       type: "topic/update",
       payload: updatedTopic,
@@ -36,16 +40,20 @@ actions.like = (topic) => {
  */
 actions.switch = (topic) => {
   return async function switchTopic(dispatch) {
-    const { switchedTo, switchedFrom } = await topicApi.switch(topic._id);
+    const res = await topicApi.switch(topic._id);
+
+    if (!res || res?.switchedTo?._id === res?.switchedFrom?._id) {
+      return;
+    }
 
     dispatch({
       type: "topic/update",
-      payload: switchedTo,
+      payload: res.switchedTo,
     });
 
     dispatch({
       type: "topic/update",
-      payload: switchedFrom,
+      payload: res.switchedFrom,
     });
   };
 };
@@ -56,11 +64,15 @@ actions.switch = (topic) => {
  */
 actions.close = (topic) => {
   return async function closeTopic(dispatch) {
-    const updatedTopic = await topicApi.close(topic._id);
+    const updated = await topicApi.close(topic._id);
+
+    if (!updated) {
+      return;
+    }
 
     dispatch({
       type: "topic/update",
-      payload: updatedTopic,
+      payload: updated,
     });
   };
 };

--- a/www/store/root.js
+++ b/www/store/root.js
@@ -8,6 +8,7 @@ import topic from "./features/topic";
 import meeting from "./features/meeting";
 import actionItem from "./features/action-item";
 import takeaway from "./features/takeaway";
+import participant from "./features/participant";
 
 const rootReducer = combineReducers({
   user: userReducer,
@@ -16,6 +17,7 @@ const rootReducer = combineReducers({
   snackbar: snackbarReducer,
   topic: topic.reducer,
   meeting: meeting.reducer,
+  participant: participant.reducer,
   takeaway: takeaway.reducer,
   actionItem: actionItem.reducer,
 });

--- a/www/styles/pages/meeting/[id]/edit.module.scss
+++ b/www/styles/pages/meeting/[id]/edit.module.scss
@@ -1,3 +1,11 @@
+.blank_container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .container {
   width: 100%;
   max-width: 1200px;


### PR DESCRIPTION
### Context

There are only three places where we aren't yet using the new store, the meeting index page (which might never use the store), the meeting edit form, and the chip form. This pr modifies the meeting edit page to use the store as well as fixing the errors that would history button errors.

### Implementation

**Meeting Form**

Because we want the edit meeting page to be responsive, it needs to maintain it's own state (it cannot afford to wait for an update request). However, we also want it to use a cached meeting if one exists to avoid any loading time. To accomplish this, I grab the existing meeting from the store if it exists using a selector and then use it to set the meeting forms state. A request to fetch the meeting is dispatched regardless of if it was cached so that any discrepancies are immediately resolved.

**History Buttons**

The issue with the history buttons originated in the routers `asPath` property being added to the `history` before the router had initialized. This resulted in the history including a record that did not have the route parameters interpolated into it ie. `user/[id]/home` was in the state instead of `user/3204509843/home`. This resulted in an error when  `router.push` was called with a string containing `[id]`.



