### PR TITLE
fix(www): rm unecessary debounces

### DIFF
--- a/www/classes/rest-api.js
+++ b/www/classes/rest-api.js
@@ -1,7 +1,6 @@
 import client from "../api/client";
 import { store } from "../store";
 import { notify } from "../store/features/snackbar";
-import debounce from "../utils/debounce";
 
 class RestAPI {
   /**
@@ -15,16 +14,6 @@ class RestAPI {
    */
   constructor(type) {
     this.type = type;
-
-    for (const property of Object.keys(this)) {
-      if (
-        property !== "constructor" &&
-        property !== "type" &&
-        typeof this[property] === "function"
-      ) {
-        this[property] = debounce(this[property], 300);
-      }
-    }
   }
 
   /**

--- a/www/components/pages/Edit/HeaderForm/HeaderForm.js
+++ b/www/components/pages/Edit/HeaderForm/HeaderForm.js
@@ -26,7 +26,7 @@ function HeaderForm({ meetingId }) {
   const debouncedDate = useDebounce(date, 250);
 
   useEffect(() => {
-    if (meeting) {
+    if (!initialized && meeting) {
       setName(meeting.name);
       setDate(meeting.date);
       setInitialized(true);
@@ -42,11 +42,17 @@ function HeaderForm({ meetingId }) {
       // Avoid sending patch after setName and setDate are called during
       // initalization.
       if (updateReady) {
+        const updates = { name };
+
+        // Don't send an update to the backend with a bad date
+        if (debouncedDate && debouncedDate.toString() !== "Invalid Date") {
+          updates.date = debouncedDate;
+        }
+
         dispatch(
           meetingStore.actions.update({
             ...meeting,
-            date: debouncedDate,
-            name: debouncedName,
+            ...updates,
           })
         );
       }
@@ -69,7 +75,11 @@ function HeaderForm({ meetingId }) {
           label="Meeting Date"
           inputFormat="MM/DD/YYYY"
           value={date}
-          onChange={(e) => setDate(e.$d)}
+          onChange={(e) => {
+            if (e) {
+              setDate(e.$d);
+            }
+          }}
           renderInput={(params) => {
             return <TextField {...params} size="small" />;
           }}

--- a/www/components/pages/Edit/HeaderForm/HeaderForm.js
+++ b/www/components/pages/Edit/HeaderForm/HeaderForm.js
@@ -1,7 +1,7 @@
 import { TextField } from "@mui/material";
 import { DesktopDatePicker } from "@mui/x-date-pickers/DesktopDatePicker";
 
-import debounce from "../../../../utils/debounce";
+import useDebounce from "../../../../hooks/use-debounce";
 
 import meetingStore from "../../../../store/features/meeting";
 
@@ -9,10 +9,6 @@ import { useDispatch, useSelector } from "react-redux";
 import { useState, useEffect } from "react";
 
 import styles from "./HeaderForm.module.css";
-
-const debouncedUpdate = debounce((data, dispatch) => {
-  dispatch(meetingStore.actions.update(data));
-}, 250);
 
 function HeaderForm({ meetingId }) {
   const dispatch = useDispatch();
@@ -25,6 +21,8 @@ function HeaderForm({ meetingId }) {
   const [date, setDate] = useState("");
   const [initialized, setInitialized] = useState(false);
 
+  const debouncedName = useDebounce(name, 250);
+
   useEffect(() => {
     if (!initialized && meeting) {
       setName(meeting.name);
@@ -33,9 +31,9 @@ function HeaderForm({ meetingId }) {
     }
   }, [meeting]);
 
-  const updateMeeting = () => {
-    debouncedUpdate({ _id: meetingId, name, date }, dispatch);
-  };
+  useEffect(() => {
+    dispatch(meetingStore.actions.update({ date, name }));
+  }, [debouncedName]);
 
   return (
     <div className={styles.meetingBar}>
@@ -46,23 +44,14 @@ function HeaderForm({ meetingId }) {
           size="small"
           value={name}
           placeholder="Meeting Name"
-          onChange={(e) => {
-            setName(e.target.value);
-            updateMeeting();
-          }}
+          onChange={(e) => setName(e.target.value)}
         />
         <DesktopDatePicker
           className={styles.date_picker}
           label="Meeting Date"
           inputFormat="MM/DD/YYYY"
           value={date}
-          onChange={(e) => {
-            setDate(e.$d);
-
-            if (e.$d !== "Invalid Date") {
-              updateMeeting({ date: e.$d });
-            }
-          }}
+          onChange={(e) => setDate(e.$d)}
           renderInput={(params) => {
             return <TextField {...params} size="small" />;
           }}

--- a/www/components/pages/Edit/HeaderForm/HeaderForm.js
+++ b/www/components/pages/Edit/HeaderForm/HeaderForm.js
@@ -20,11 +20,13 @@ function HeaderForm({ meetingId }) {
   const [name, setName] = useState("");
   const [date, setDate] = useState("");
   const [initialized, setInitialized] = useState(false);
+  const [updateReady, setUpdateReady] = useState(false);
 
   const debouncedName = useDebounce(name, 250);
+  const debouncedDate = useDebounce(date, 250);
 
   useEffect(() => {
-    if (!initialized && meeting) {
+    if (meeting) {
       setName(meeting.name);
       setDate(meeting.date);
       setInitialized(true);
@@ -32,8 +34,24 @@ function HeaderForm({ meetingId }) {
   }, [meeting]);
 
   useEffect(() => {
-    dispatch(meetingStore.actions.update({ date, name }));
-  }, [debouncedName]);
+    if (initialized) {
+      if (!updateReady) {
+        setUpdateReady(true);
+      }
+
+      // Avoid sending patch after setName and setDate are called during
+      // initalization.
+      if (updateReady) {
+        dispatch(
+          meetingStore.actions.update({
+            ...meeting,
+            date: debouncedDate,
+            name: debouncedName,
+          })
+        );
+      }
+    }
+  }, [debouncedName, debouncedDate, dispatch]);
 
   return (
     <div className={styles.meetingBar}>

--- a/www/components/pages/Meet/ActionItemBoard/ActionItemBoard.js
+++ b/www/components/pages/Meet/ActionItemBoard/ActionItemBoard.js
@@ -4,19 +4,24 @@ import CardForm from "../../../shared/CardForm/CardForm";
 import topicStore from "../../../../store/features/topic";
 import actionItemStore from "../../../../store/features/action-item";
 
+import { useEffect } from "react";
+
 import { useDispatch } from "react-redux";
 
 export default function ActionItemBoard({ liveTopic, meetingId, hidden }) {
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (liveTopic) {
+      dispatch(topicStore.actions.getActionItems(liveTopic._id));
+    }
+  }, [dispatch]);
 
   return (
     <div hidden={hidden}>
       <CardBoard
         selector={(state) =>
           topicStore.selectors.actionItems(state, liveTopic._id)
-        }
-        getAll={() =>
-          dispatch(topicStore.actions.getActionItems(liveTopic._id))
         }
         create={(payload) =>
           dispatch(

--- a/www/components/pages/Meet/TakeawayBoard/TakeawayBoard.js
+++ b/www/components/pages/Meet/TakeawayBoard/TakeawayBoard.js
@@ -4,10 +4,18 @@ import CardForm from "../../../shared/CardForm/CardForm";
 import takeawayStore from "../../../../store/features/takeaway";
 import topicStore from "../../../../store/features/topic";
 
+import { useEffect } from "react";
+
 import { useDispatch } from "react-redux";
 
 export default function TakeawayBoard({ liveTopic, meetingId, hidden }) {
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (liveTopic) {
+      dispatch(topicStore.actions.getTakeaways(liveTopic._id));
+    }
+  }, [dispatch]);
 
   return (
     <div hidden={hidden}>
@@ -15,7 +23,6 @@ export default function TakeawayBoard({ liveTopic, meetingId, hidden }) {
         selector={(state) =>
           topicStore.selectors.takeaways(state, liveTopic._id)
         }
-        getAll={() => dispatch(topicStore.actions.getTakeaways(liveTopic._id))}
         create={(payload) =>
           dispatch(
             takeawayStore.actions.create({

--- a/www/components/shared/CardBoard/CardBoard.js
+++ b/www/components/shared/CardBoard/CardBoard.js
@@ -1,7 +1,6 @@
 import AddCircleIcon from "@mui/icons-material/AddCircle";
 import Button from "@mui/material/Button";
 
-import { useState, useEffect } from "react";
 import { useSelector } from "react-redux";
 
 import styles from "./CardBoard.module.css";
@@ -10,7 +9,6 @@ import styles from "./CardBoard.module.css";
  * General board component that displays a list of crud cards
  *
  * @param {Object} props
- * @param {Function} getAll - function to retrieve data
  * @param {Function} selector - selector function to get data from store
  * @param {Function} create - function that takes a payload and creates
  * a new item using the payload
@@ -20,25 +18,8 @@ import styles from "./CardBoard.module.css";
  * @param {Component} Card - card to use
  * @param {string} itemName - name of item (ie 'takeaway', 'action item')
  */
-const CardBoard = ({
-  selector,
-  getAll,
-  create,
-  update,
-  destroy,
-  Card,
-  itemName,
-}) => {
+const CardBoard = ({ selector, create, update, destroy, Card, itemName }) => {
   const items = useSelector(selector);
-
-  const [initailized, setInitialized] = useState(false);
-
-  useEffect(() => {
-    if (!initailized) {
-      getAll();
-      setInitialized(true);
-    }
-  }, [initailized, getAll]);
 
   const createItem = async () => {
     create({ name: "", description: "" });

--- a/www/components/shared/ChipForm/ChipForm.js
+++ b/www/components/shared/ChipForm/ChipForm.js
@@ -7,7 +7,7 @@ import { Chip } from "@mui/material";
 
 import IconTextField from "../IconTextField/IconTextField";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useSelector } from "react-redux";
 
 import styles from "./ChipForm.module.css";
@@ -17,26 +17,16 @@ import styles from "./ChipForm.module.css";
  *
  * @param {String} itemKey - key unique among chips that will be displayed
  * @param {String} itemName - singular type of items (eg. participant)
- * @param {Function} getAll - async function to fetch all items that should be
- * displayed in the form
  * @param {Function} create - async function to create a new item in the form
  * given a `payload` as a param
  * @param {Function} destroy - async function to delete an item in the form
  * given an `id` as a param
  */
-function ChipForm({ itemName, itemKey, selector, getAll, create, destroy }) {
+function ChipForm({ itemName, itemKey, selector, create, destroy }) {
   const items = useSelector(selector);
   const store = useStore();
 
   const [input, setInput] = useState("");
-  const [initLoad, setInitLoad] = useState(true);
-
-  useEffect(() => {
-    if (initLoad) {
-      getAll();
-      setInitLoad(false);
-    }
-  }, [initLoad]);
 
   const createChip = async (key) => {
     const duplicates = items.filter((item) => {

--- a/www/hooks/use-debounce.js
+++ b/www/hooks/use-debounce.js
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+
+export default function useDebounce(value, delay) {
+  const [val, setVal] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setVal(value), delay || 500);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return val;
+}

--- a/www/pages/login.js
+++ b/www/pages/login.js
@@ -37,7 +37,7 @@ const Login = (props) => {
 
         const user = props.store.getState().user;
 
-        router.push(`/user/${user._id}/home`);
+        router.replace(`/user/${user._id}/home`);
       } catch (err) {
         await props.store.dispatch(
           notify({

--- a/www/pages/meeting/[id]/edit.js
+++ b/www/pages/meeting/[id]/edit.js
@@ -29,33 +29,24 @@ const Meeting = (props) => {
   );
 
   const [initialized, setInitialized] = useState(false);
-  const [name, setName] = useState("");
-  const [date, setDate] = useState("");
   const [status, setStatus] = useState("");
 
   useEffect(() => {
     if (!initialized && meeting_id) {
       dispatch(meetingStore.actions.get(meeting_id));
+      dispatch(meetingStore.actions.getParticipants(meeting_id));
+      dispatch(meetingStore.actions.getTopics(meeting_id));
+
       setInitialized(true);
     }
 
     if (meeting) {
-      setName(meeting.name);
-      setDate(meeting.date);
       setStatus(meeting.status);
     }
   }, [meeting, props.store, router.query.id]);
 
-  const updateMeeting = ({ name, date }) => {
-    dispatch(meetingStore.actions.update({ name, date, _id: meeting_id }));
-
-    setName(name);
-    setDate(date);
-  };
-
   const updateMeetingStatus = ({ status }) => {
     dispatch(meetingStore.actions.updateStatus(meeting_id, status));
-
     setStatus(status);
   };
 
@@ -74,7 +65,7 @@ const Meeting = (props) => {
       <div className={shared.page}>
         <div className={styles.container}>
           <section className={styles.header}>
-            <h2 className={shared.page_title}>Edit Meeting: {name}</h2>
+            <h2 className={shared.page_title}>Edit Meeting: {meeting.name}</h2>
             <StatusButton
               status={status}
               setMeetingStatus={(status) => updateMeetingStatus({ status })}
@@ -82,14 +73,7 @@ const Meeting = (props) => {
           </section>
           <section className={shared.card + " " + styles.section}>
             <h3 className={styles.card_title}>Meeting Details</h3>
-            <HeaderForm
-              meetingName={name}
-              setMeetingName={(e) =>
-                updateMeeting({ name: e.target.value, date })
-              }
-              meetingDate={date}
-              setMeetingDate={(e) => updateMeeting({ name, date: e.$d })}
-            />
+            <HeaderForm meetingId={meeting_id} />
           </section>
           <section className={shared.card + " " + styles.section}>
             <h3>Participants</h3>
@@ -99,9 +83,6 @@ const Meeting = (props) => {
               }
               itemKey={"email"}
               itemName={"participant"}
-              getAll={() =>
-                dispatch(meetingStore.actions.getParticipants(meeting_id))
-              }
               create={(item) =>
                 dispatch(
                   participantStore.actions.create({
@@ -124,9 +105,6 @@ const Meeting = (props) => {
             <CardBoard
               selector={(state) =>
                 meetingStore.selectors.topics(state, meeting_id)
-              }
-              getAll={() =>
-                dispatch(meetingStore.actions.getTopics(meeting_id))
               }
               create={(payload) =>
                 dispatch(

--- a/www/pages/meeting/[id]/meet.js
+++ b/www/pages/meeting/[id]/meet.js
@@ -7,6 +7,7 @@ import LoadingIcon from "../../../components/shared/LoadingIcon/LoadingIcon";
 
 import { ToggleButtonGroup } from "@mui/material";
 import { ToggleButton } from "@mui/material";
+import { Fade } from "@mui/material";
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
@@ -62,59 +63,63 @@ export default function MeetRevamp() {
   }
 
   return (
-    <div className={shared.page}>
-      <div className={styles.container}>
-        <div className={styles.header}>
-          <h2>Meet: {meeting.name}</h2>
-        </div>
-        <div className={styles.main_grid}>
-          <div>
-            <TopicSelectBar
-              meetingName={meeting.name}
-              topics={topics}
-              switchToTopic={(t) => dispatch(topicStore.actions.switch(t))}
-            />
+    <Fade in={true}>
+      <div className={shared.page}>
+        <div className={styles.container}>
+          <div className={styles.header}>
+            <h2>Meet: {meeting.name}</h2>
           </div>
-          <div>
-            {liveTopic ? (
-              <TopicDisplay
-                topic={liveTopic}
-                closeTopic={(t) => dispatch(topicStore.actions.close(t))}
+          <div className={styles.main_grid}>
+            <div>
+              <TopicSelectBar
+                meetingName={meeting.name}
+                topics={topics}
+                switchToTopic={(t) => dispatch(topicStore.actions.switch(t))}
               />
-            ) : (
-              <p>No topic selected. Select a topic on the left to begin.</p>
-            )}
-            {liveTopic && (
-              <div className={styles.tabs_container}>
-                <ToggleButtonGroup
-                  className={styles.button_group}
-                  size="small"
-                  color="primary"
-                  value={tab}
-                  exclusive
-                  onChange={(_, ta) => changeTab(ta)}
-                >
-                  <ToggleButton value="Takeaways">Takeaways</ToggleButton>
-                  <ToggleButton value="Action Items">Action Items</ToggleButton>
-                </ToggleButtonGroup>
-                <TakeawayBoard
-                  hidden={tab !== "Takeaways"}
-                  liveTopic={liveTopic}
-                  meetingId={meeting_id}
+            </div>
+            <div>
+              {liveTopic ? (
+                <TopicDisplay
+                  topic={liveTopic}
+                  closeTopic={(t) => dispatch(topicStore.actions.close(t))}
                 />
-                <ActionItemBoard
-                  hidden={tab !== "Action Items"}
-                  liveTopic={liveTopic}
-                  meetingId={meeting_id}
-                />
-              </div>
-            )}
-          </div>
-          <div>
-            <ActionItemBar meetingId={meeting_id} />
+              ) : (
+                <p>No topic selected. Select a topic on the left to begin.</p>
+              )}
+              {liveTopic && (
+                <div className={styles.tabs_container}>
+                  <ToggleButtonGroup
+                    className={styles.button_group}
+                    size="small"
+                    color="primary"
+                    value={tab}
+                    exclusive
+                    onChange={(_, ta) => changeTab(ta)}
+                  >
+                    <ToggleButton value="Takeaways">Takeaways</ToggleButton>
+                    <ToggleButton value="Action Items">
+                      Action Items
+                    </ToggleButton>
+                  </ToggleButtonGroup>
+                  <TakeawayBoard
+                    hidden={tab !== "Takeaways"}
+                    liveTopic={liveTopic}
+                    meetingId={meeting_id}
+                  />
+                  <ActionItemBoard
+                    hidden={tab !== "Action Items"}
+                    liveTopic={liveTopic}
+                    meetingId={meeting_id}
+                  />
+                </div>
+              )}
+            </div>
+            <div>
+              <ActionItemBar meetingId={meeting_id} />
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </Fade>
   );
 }

--- a/www/pages/register.js
+++ b/www/pages/register.js
@@ -75,6 +75,10 @@ const Register = (props) => {
 
   useEffect(() => {
     const checkEmail = async () => {
+      if (!email) {
+        return;
+      }
+
       try {
         await client.post("user/checkexistingemail", { email });
 
@@ -93,6 +97,10 @@ const Register = (props) => {
 
   useEffect(() => {
     const checkUsername = async () => {
+      if (!username) {
+        return;
+      }
+
       try {
         await client.post("user/checkexistingusername", {
           username: username,
@@ -107,6 +115,7 @@ const Register = (props) => {
         }
       }
     };
+
     checkUsername();
   }, [debouncedUsername]);
 

--- a/www/pages/register.js
+++ b/www/pages/register.js
@@ -6,6 +6,8 @@ import TextField from "@mui/material/TextField";
 
 import { notify } from "../store/features/snackbar";
 
+import useDebounce from "../hooks/use-debounce";
+
 import { useState } from "react";
 import { useEffect } from "react";
 import { userRegister } from "../store/features/user";
@@ -14,28 +16,29 @@ import client from "../api/client";
 
 import styles from "../styles/pages/register.module.css";
 
-const initialState = {
-  email: "",
-  username: "",
-  password: "",
-};
-
 const Register = (props) => {
-  const [registering, setRegistering] = useState(false);
-
   const router = useRouter();
-  const [fields, setFields] = useState(initialState);
+
+  const [registering, setRegistering] = useState(false);
+  const [email, setEmail] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
   const [emailError, setEmailError] = useState(false);
   const [usernameError, setUsernameError] = useState(false);
 
-  const handleChange = (event) => {
-    setFields({ ...fields, [event.target.name]: event.target.value });
-  };
+  const debouncedEmail = useDebounce(email, 500);
+  const debouncedUsername = useDebounce(username, 500);
 
   useEffect(() => {
     const register = async () => {
       try {
-        await props.store.dispatch(userRegister(fields));
+        await props.store.dispatch(
+          userRegister({
+            email,
+            username,
+            password,
+          })
+        );
 
         await props.store.dispatch(
           notify({
@@ -46,7 +49,7 @@ const Register = (props) => {
 
         const user = props.store.getState().user;
 
-        router.push(`/user/${user._id}/home`);
+        router.replace(`/user/${user._id}/home`);
       } catch (err) {
         await props.store.dispatch(
           notify({
@@ -55,8 +58,6 @@ const Register = (props) => {
             ms: 3000,
           })
         );
-
-        setFields(initialState);
       }
 
       setRegistering(false);
@@ -75,30 +76,30 @@ const Register = (props) => {
   useEffect(() => {
     const checkEmail = async () => {
       try {
-        await client.post("user/checkexistingemail", { email: fields.email });
+        await client.post("user/checkexistingemail", { email });
 
         if (emailError) {
           setEmailError(false);
         }
       } catch (err) {
         if (err.response.status === 409) {
-          setEmailError("username already in use");
+          setEmailError("email already in use");
         }
       }
     };
 
     checkEmail();
-  }, [fields.email]);
+  }, [debouncedEmail]);
 
   useEffect(() => {
     const checkUsername = async () => {
       try {
         await client.post("user/checkexistingusername", {
-          username: fields.username,
+          username: username,
         });
 
         if (usernameError) {
-          setEmailError(false);
+          setUsernameError(false);
         }
       } catch (err) {
         if (err.response.status === 409) {
@@ -107,7 +108,7 @@ const Register = (props) => {
       }
     };
     checkUsername();
-  }, [fields.username]);
+  }, [debouncedUsername]);
 
   return (
     <div className={styles.form_container}>
@@ -117,27 +118,27 @@ const Register = (props) => {
           name="email"
           label="email"
           variant="standard"
-          value={fields.email}
-          onChange={handleChange}
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
           className={styles.text_field}
-          error={emailError}
+          helperText={emailError}
         />
         <TextField
           name="username"
           label="username"
           variant="standard"
-          value={fields.username}
-          onChange={handleChange}
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
           className={styles.text_field}
-          error={usernameError}
+          helperText={usernameError}
         />
         <TextField
           name="password"
           label="password"
           type="password"
           variant="standard"
-          value={fields.password}
-          onChange={handleChange}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
           className={styles.text_field}
         />
         <div className={styles.login_button_container}>

--- a/www/store/features/topic.js
+++ b/www/store/features/topic.js
@@ -46,15 +46,19 @@ actions.switch = (topic) => {
       return;
     }
 
-    dispatch({
-      type: "topic/update",
-      payload: res.switchedTo,
-    });
+    if (res.switchedTo) {
+      dispatch({
+        type: "topic/update",
+        payload: res.switchedTo,
+      });
+    }
 
-    dispatch({
-      type: "topic/update",
-      payload: res.switchedFrom,
-    });
+    if (res.switchedFrom) {
+      dispatch({
+        type: "topic/update",
+        payload: res.switchedFrom,
+      });
+    }
   };
 };
 

--- a/www/store/utils/slice-generator.js
+++ b/www/store/utils/slice-generator.js
@@ -47,19 +47,27 @@ export function generateReducers(schema) {
     reducers[`set${capitalize(k)}`] = (state, action) => {
       const { _id, [`${v}Ids`]: refIds } = action.payload;
 
-      state[_id][k] = refIds;
+      state[_id] = { ...state[_id], [k]: refIds };
     };
 
     reducers[`create${dispName}`] = (state, action) => {
       const { _id, [`${v}Id`]: refId } = action.payload;
 
-      state[_id][k].push(refId);
+      if (Array.isArray(state[_id]?.[k])) {
+        state[_id][k].push(refId);
+      } else {
+        state[_id][k] = [refId];
+      }
     };
 
     reducers[`delete${dispName}`] = (state, action) => {
       const { _id, [`${v}Id`]: refId } = action.payload;
 
-      state[_id][k] = state[_id][k].filter((id) => id !== refId);
+      if (Array.isArray(state[_id]?.[k])) {
+        state[_id][k] = state[_id][k].filter((id) => id !== refId);
+      } else {
+        state[_id][k] = [];
+      }
     };
   });
 
@@ -204,7 +212,7 @@ export function generateSelectors(schema) {
 
   Object.entries(schema.references).forEach(([k, v]) => {
     selectors[k] = (state, id) => {
-      if (!id || !state[schema.name][id]) {
+      if (!id || !state[schema.name]?.[id]?.[k]) {
         return [];
       }
 

--- a/www/styles/pages/register.module.css
+++ b/www/styles/pages/register.module.css
@@ -18,12 +18,14 @@
 .form_title {
   width: 100%;
   color: var(--secondary);
-  margin-bottom: 5px;
+  /* Extra space for error messages */
+  margin-bottom: 10px;
 }
 
 .text_field {
   width: 100%;
-  margin-bottom: 25px;
+  /* Extra space for error messages */
+  margin-bottom: 30px;
 }
 
 .login_button_container {


### PR DESCRIPTION
After playing around with the updated version of the store I noticed that there were unexpected delays in requests which made things slightly less snappy. You couldn't really notice them before because there was a lot more load times. However, with the new store a lot of stuff gets cached which means that the vast majority of actions now take less than 50ms so the extra debounce delay was bothersome. We only really need to debounce text inputs that send real time updates which is only relevant for the meeting edit page and register page so I removed debounce from clients and added a new debounce hook.

I also moved the state management of the `HeaderForm` to the component since it isn't really related to the page and the page can just subscript to the store.