### PR TITLE
Fix Cors and Make Auth Response Meet RFC6749

### DIFF
--- a/api/lib/controllers/pubkey.js
+++ b/api/lib/controllers/pubkey.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+  pubkey(req, res) {
+    const key = fs.readFileSync(
+      path.join(__dirname, "../../keys/id_rsa_pub.pem"),
+      "utf8"
+    );
+
+    return res.status(200).send(key);
+  },
+};

--- a/api/lib/controllers/user.js
+++ b/api/lib/controllers/user.js
@@ -47,8 +47,8 @@ module.exports = {
         email: user.email,
         username: user.username,
       },
-      token,
-      expiresIn,
+      access_token: token,
+      expires_in: expiresIn,
     });
   },
 

--- a/api/lib/routes/index.js
+++ b/api/lib/routes/index.js
@@ -9,6 +9,7 @@ const ui = require("./ui");
 const participant = require("./participant");
 const takeaway = require("./takeaway");
 const actionItem = require("./action-item");
+const pubkey = require("./pubkey");
 
 router.use("/health", health);
 router.use("/user", reqLogger, user);
@@ -18,5 +19,6 @@ router.use("/takeaway", reqLogger, authMdw, takeaway);
 router.use("/action-item", reqLogger, authMdw, actionItem);
 router.use("/participant", reqLogger, authMdw, participant);
 router.use("/ui", reqLogger, authMdw, ui);
+router.use("/pubkey", reqLogger, pubkey);
 
 module.exports = router;

--- a/api/lib/routes/pubkey.js
+++ b/api/lib/routes/pubkey.js
@@ -1,0 +1,9 @@
+const router = require("express").Router();
+const keyController = require("../controllers/pubkey");
+const { wrapController } = require("../util/error-wrapper");
+
+const wrapped = wrapController(keyController);
+
+router.get("/", wrapped.pubkey);
+
+module.exports = router;

--- a/api/test/tests/controllers/action-item.test.js
+++ b/api/test/tests/controllers/action-item.test.js
@@ -37,13 +37,13 @@ describe("lib/controllers/action-item", () => {
     ]);
 
     this.user = user1.data.user;
-    this.token = user1.data.token;
+    this.token = user1.data.access_token;
 
     this.user2 = user2.data.user;
-    this.token2 = user2.data.token;
+    this.token2 = user2.data.access_token;
 
     this.participant = participant.data.user;
-    this.participantToken = participant.data.token;
+    this.participantToken = participant.data.access_token;
   });
 
   beforeEach(async () => {

--- a/api/test/tests/controllers/meeting.test.js
+++ b/api/test/tests/controllers/meeting.test.js
@@ -33,7 +33,7 @@ describe("lib/controllers/meeting", () => {
     });
 
     this.user = res.data.user;
-    this.token = res.data.token;
+    this.token = res.data.access_token;
 
     const res2 = await client.post("/user/register", {
       username: "user2",
@@ -42,7 +42,7 @@ describe("lib/controllers/meeting", () => {
     });
 
     this.user2 = res2.data.user;
-    this.token2 = res2.data.token;
+    this.token2 = res2.data.access_token;
   });
 
   beforeEach(async () => {

--- a/api/test/tests/controllers/participant.test.js
+++ b/api/test/tests/controllers/participant.test.js
@@ -21,7 +21,7 @@ describe("lib/controllers/participant", () => {
     });
 
     this.user = res.data.user;
-    this.token = res.data.token;
+    this.token = res.data.access_token;
   });
 
   beforeEach(async () => {

--- a/api/test/tests/controllers/pubkey.test.js
+++ b/api/test/tests/controllers/pubkey.test.js
@@ -1,0 +1,29 @@
+const { assert } = require("chai");
+const api = require("../../utils/api");
+const client = require("../../utils/client");
+const fs = require("fs");
+const path = require("path");
+
+describe("lib/controllers/pubkey.js", () => {
+  const urlPath = "/pubkey";
+
+  before(async () => {
+    await api.start();
+  });
+
+  after(async () => {
+    await api.stop();
+  });
+
+  it("should respond with a public key", async () => {
+    const res = await client.get(urlPath);
+
+    const key = fs.readFileSync(
+      path.join(__dirname, "../../../keys/id_rsa_pub.pem"),
+      "utf8"
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(res.data, key);
+  });
+});

--- a/api/test/tests/controllers/takeway.test.js
+++ b/api/test/tests/controllers/takeway.test.js
@@ -33,7 +33,7 @@ describe("lib/controllers/takeaway", () => {
   });
 
   beforeEach(async () => {
-    client.defaults.headers.common["Authorization"] = this.user.token;
+    client.defaults.headers.common["Authorization"] = this.user.access_token;
 
     await dbUtils.clean(["takeaways", "topics"]);
 
@@ -88,7 +88,7 @@ describe("lib/controllers/takeaway", () => {
     it("should 403 if not meeting owner or participant", async () => {
       const takeaway = fakeTakeaway({ topic_id: this.topic._id });
 
-      client.defaults.headers.common["Authorization"] = this.user2.token;
+      client.defaults.headers.common["Authorization"] = this.user2.access_token;
 
       try {
         await client.post(path, takeaway);
@@ -135,7 +135,7 @@ describe("lib/controllers/takeaway", () => {
     });
 
     it("should 403 if not takeaway owner", async () => {
-      client.defaults.headers.common["Authorization"] = this.user2.token;
+      client.defaults.headers.common["Authorization"] = this.user2.access_token;
 
       try {
         await client.patch(path + "/" + this.takeaway._id, {});
@@ -181,7 +181,7 @@ describe("lib/controllers/takeaway", () => {
 
       const resTakeaway = await client.post(path, takeaway);
 
-      client.defaults.headers.common["Authorization"] = this.user2.token;
+      client.defaults.headers.common["Authorization"] = this.user2.access_token;
 
       try {
         await client.delete(path + "/" + resTakeaway.data._id);

--- a/api/test/tests/controllers/topic.test.js
+++ b/api/test/tests/controllers/topic.test.js
@@ -39,10 +39,10 @@ describe("lib/controllers/topic", () => {
     ).data;
 
     this.user = res.user;
-    this.token = res.token;
+    this.token = res.access_token;
 
     this.user2 = res2.user;
-    this.token2 = res2.token;
+    this.token2 = res2.access_token;
   });
 
   beforeEach(async () => {

--- a/api/test/tests/controllers/ui.test.js
+++ b/api/test/tests/controllers/ui.test.js
@@ -23,7 +23,7 @@ describe("lib/controllers/ui", () => {
 
     user_id = res.data.user._id;
 
-    client.defaults.headers.common["Authorization"] = res.data.token;
+    client.defaults.headers.common["Authorization"] = res.data.access_token;
   });
 
   beforeEach(async () => {

--- a/api/test/tests/controllers/user.test.js
+++ b/api/test/tests/controllers/user.test.js
@@ -63,7 +63,7 @@ describe("lib/controllers/user.js", () => {
 
       const tokenRegex = new RegExp(/^Bearer\s/);
 
-      assert(tokenRegex.test(res.data.token));
+      assert(tokenRegex.test(res.data.access_token));
     });
 
     it("should not register user with invalid email", async () => {
@@ -153,7 +153,7 @@ describe("lib/controllers/user.js", () => {
     beforeEach(async () => {
       const { data } = await client.post("/user/register", user);
 
-      token = data.token;
+      token = data.access_token;
       user_id = data.user._id;
     });
 

--- a/www/api/client.js
+++ b/www/api/client.js
@@ -1,18 +1,5 @@
 import axios from "axios";
-import { getCookie } from "../utils/cookie";
 
-const hostname = process.env.NEXT_PUBLIC_API_HOSTNAME;
-const path = `api`;
-
-const client = axios.create({
-  baseURL: `${hostname}/${path}`,
-  timeout: 1000,
-});
-
-client.interceptors.request.use((config) => {
-  config.headers["authorization"] = getCookie("agenda-auth");
-
-  return config;
-});
+const client = axios.create({ baseURL: "/api" });
 
 export default client;

--- a/www/pages/api/[...slug].js
+++ b/www/pages/api/[...slug].js
@@ -1,0 +1,42 @@
+import axios from "axios";
+
+const hostname = process.env.NEXT_PUBLIC_API_HOSTNAME;
+
+const publicRoutes = ["/api/user/login", "/api/user/register"];
+
+async function proxyRequest(req) {
+  delete req.query.slug;
+
+  const args = [
+    hostname + req.url,
+    ...(["GET", "DELETE"].includes(req.method) ? [] : [req.body]),
+    {
+      params: req.query,
+      headers: {
+        authorization: req.cookies["agenda-auth"],
+      },
+    },
+  ];
+
+  const res = await axios[req.method.toLowerCase()](...args);
+
+  return res.data;
+}
+
+export default async (req, res) => {
+  if (publicRoutes.includes(req.url)) {
+    const data = await proxyRequest(req);
+
+    res.setHeader(`Set-Cookie`, `agenda-auth=${data.token}; path=/; HttpOnly`);
+
+    return res.status(200).json(data);
+  }
+
+  try {
+    const data = await proxyRequest(req);
+
+    return res.status(200).json(data);
+  } catch (err) {
+    return res.status(err.response.status).json(err.response.data);
+  }
+};

--- a/www/store/features/user.js
+++ b/www/store/features/user.js
@@ -36,14 +36,12 @@ const reducer = (state = initialState, action) => {
  * @returns {Promise<undefined>}
  */
 export const userRegister = ({ email, username, password }) => {
-  return async function registerUser(dispatch, getState) {
+  return async function registerUser(dispatch) {
     const { data } = await client.post("/user/register", {
       email,
       username,
       password,
     });
-
-    setCookie("agenda-auth", data.token);
 
     dispatch({
       type: "user/register",
@@ -64,13 +62,11 @@ export const userRegister = ({ email, username, password }) => {
  * @returns {Promise<undefined>}
  */
 export const userLogin = ({ username, password }) => {
-  return async function loginUser(dispatch, getState) {
+  return async function loginUser(dispatch) {
     const { data } = await client.post("/user/login", {
       username,
       password,
     });
-
-    setCookie("agenda-auth", data.token);
 
     dispatch({
       type: "user/login",
@@ -89,7 +85,7 @@ export const userLogin = ({ username, password }) => {
  * @returns {Promise<undefined>}
  */
 export const userRefresh = () => {
-  return async function refreshUser(dispatch, getState) {
+  return async function refreshUser(dispatch) {
     const token = getCookie("agenda-auth");
 
     if (token) {
@@ -119,9 +115,8 @@ export const userRefresh = () => {
  * @returns {Promise<undefined>}
  */
 export const userLogout = () => {
-  return async function logoutUser(dispatch, getState) {
+  return async function logoutUser(dispatch) {
     setCookie("agenda-auth", "");
-    localStorage.removeItem("theme");
 
     dispatch({
       type: "user/logout",


### PR DESCRIPTION
I'm not entirely sure how this wasn't noticed yet but the current CORS setup doesn't allow requests from `www.meetingminder.dev` only `meetingminder.dev` (the exact origin of the api). To resolve this, I am modifying the client to always hit the web server which will proxy requests to meetingminder.dev. If you are wondering why we don't just add another item to the CORS allowed origins, the main reason is that by using the proxy setup we can use the native cookies in the browser and just convert the cookies to bearer tokens at the proxy. This makes the axios configuration much simpler while still maintaining a single auth strategy for the api.