### PR TITLE
fix(store): remove token references from user store

### DIFF
--- a/www/components/Layout/Nav/Nav.js
+++ b/www/components/Layout/Nav/Nav.js
@@ -95,7 +95,7 @@ const Nav = () => {
     }
   }, [router]);
 
-  if (!user.token) {
+  if (!user._id) {
     return (
       <>
         <nav className={styles.nav}>

--- a/www/store/features/user.js
+++ b/www/store/features/user.js
@@ -1,9 +1,8 @@
 import client from "../../api/client";
-import { getCookie, setCookie } from "../../utils/cookie";
+import { setCookie } from "../../utils/cookie";
 import router from "next/router";
 
 const initialState = {
-  token: null,
   _id: null,
   username: null,
   email: null,
@@ -46,7 +45,6 @@ export const userRegister = ({ email, username, password }) => {
     dispatch({
       type: "user/register",
       payload: {
-        token: data.token,
         _id: data.user._id,
         username: data.user.username,
         email: data.user.email,
@@ -71,7 +69,6 @@ export const userLogin = ({ username, password }) => {
     dispatch({
       type: "user/login",
       payload: {
-        token: data.token,
         _id: data.user._id,
         username: data.user.username,
         email: data.user.email,
@@ -81,31 +78,24 @@ export const userLogin = ({ username, password }) => {
 };
 
 /**
- * Refresh the user state based on auth token
+ * Refresh the user state based on auth cookie
  * @returns {Promise<undefined>}
  */
 export const userRefresh = () => {
   return async function refreshUser(dispatch) {
-    const token = getCookie("agenda-auth");
+    try {
+      const { data } = await client.get("user/refresh");
 
-    if (token) {
-      try {
-        const { data } = await client.get("user/refresh", {
-          headers: { authorization: token },
-        });
-
-        dispatch({
-          type: "user/refresh",
-          payload: {
-            token,
-            _id: data.user._id,
-            username: data.user.username,
-            email: data.user.email,
-          },
-        });
-      } catch (err) {
-        console.error(err);
-      }
+      dispatch({
+        type: "user/refresh",
+        payload: {
+          _id: data.user._id,
+          username: data.user.username,
+          email: data.user.email,
+        },
+      });
+    } catch (err) {
+      console.error(err);
     }
   };
 };


### PR DESCRIPTION
We originally used the token in the store to give to the client and to determine if a user had authenticated. However, we are just using a cookie that axios automatically uses now so we can make things more secure by not storing the token anywhere else.