### PR TITLE
feat(www:Edit): validate participant emails

### DIFF
--- a/www/pages/meeting/[id]/edit.js
+++ b/www/pages/meeting/[id]/edit.js
@@ -83,6 +83,11 @@ const Meeting = (props) => {
               }
               itemKey={"email"}
               itemName={"participant"}
+              validate={(key) => {
+                // eslint-disable-next-line
+                return /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g.test(key);
+              }}
+              validateMsg={"Invalid email address."}
               create={(item) =>
                 dispatch(
                   participantStore.actions.create({


### PR DESCRIPTION
We weren't really doing any kind of validation of participant emails. This PR adds a validate function as a prop to the ChipForm as well as a validateMsg. When the validate function returns false for an itemKey, it will display the error message on the input. It is a bit nicer then the big bottom error banner because it draws the user to the problem in the form.