### PR TITLE
Added Community Documents

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,50 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+assignees:
+  - octocat
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Please describe how we can reproduce the issue.
+      placeholder: How can we reproduce the issue?
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://example.com)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[Zbarnz@yahoo.com](mailto:zbarnz@yahoo.com).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,10 @@ Please note we have a [code of conduct](https://github.com/SocexSolutions/agenda
 - Think about edge cases.
 
 ### Backend:
-- make sure any additional features or changes to existing features are covered under the tests in `api/test/tests`
-- run `npm run test` in console and confirm all tests are passing
-- ensure changes function as expected on the front end
+
+- Make sure any additional features or changes to existing features are covered under the tests in `api/test/tests`
+- Run `npm run test` in console and confirm all tests are passing
+- Ensure changes function as expected on the front end
 
 ## Pull Request Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Please note we have a [code of conduct](https://github.com/SocexSolutions/agenda
 - See if you can find the cause of the problem. You might be able to fix the problem and score an easy contribution
 - Check the [issues](https://github.com/SocexSolutions/agenda-v2/issues) page for similar existing bug reports
 
-### Submitting a report:
+### Submitting a Report:
 - Navigate to [issues](https://github.com/SocexSolutions/agenda-v2/issues) and click `New issue`
 - Use a clear and descriptive title describing the bug you are seeing
 - Select the bug issue template and fill out the form

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+:partying_face::cowboy_hat_face::tada::+1: Welcome to MeetingMinder :+1::tada::cowboy_hat_face::partying_face:
+
+## Resources
+- [Getting Started / Setup](https://github.com/SocexSolutions/agenda-v2/blob/master/README.md)
+- [Docs](https://github.com/SocexSolutions/agenda-v2/tree/master/docs)
+- [Issues](https://github.com/SocexSolutions/agenda-v2/issues)
+
+## Summary
+
+When contributing to MeetingMinder, if there is not already an issue open, please first discuss the change you wish to make via issue before making a change. 
+
+Please note we have a [code of conduct](https://github.com/SocexSolutions/agenda-v2/blob/master/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+
+## Testing
+
+### Frontend:
+
+- Spend some time testing what your changes affected. 
+- Try to break your own feature. 
+- Think about edge cases.
+
+### Backend:
+- make sure any additional features or changes to existing features are covered under the tests in `api/test/tests`
+- run `npm run test` in console and confirm all tests are passing
+- ensure changes function as expected on the front end
+
+## Pull Request Process
+
+1. Write your pull request description according to the [pull request template](https://github.com/SocexSolutions/agenda-v2/blob/master/pull_request_template.md)
+2. Assign your pull request to a SocexSolutions developer under the github assign tab. This developer will handle assigning reviewers
+3. Reply to discussions. There may be cases where a developer requests a change before the Pull Request can be merged.
+4. You may merge the Pull Request in once you have the sign-off of one other SocexSolutions developer, or if you do not have permission to do that, you may request the reviewer to merge it for you.
+
+## Bug Reports
+
+### Before reporting
+- See if you can find the cause of the problem. You might be able to fix the problem and score an easy contribution
+- Check the [issues](https://github.com/SocexSolutions/agenda-v2/issues) page for similar existing bug reports
+
+### Submitting a report:
+- Navigate to [issues](https://github.com/SocexSolutions/agenda-v2/issues) and click `New issue`
+- Use a clear and descriptive title describing the bug you are seeing
+- Select the bug issue template and fill out the form
+
+## Thanks for being a part of MeetingMinder!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Please note we have a [code of conduct](https://github.com/SocexSolutions/agenda
 
 ## Bug Reports
 
-### Before reporting
+### Before Reporting
 - See if you can find the cause of the problem. You might be able to fix the problem and score an easy contribution
 - Check the [issues](https://github.com/SocexSolutions/agenda-v2/issues) page for similar existing bug reports
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@
 
 ## Summary
 
-When contributing to MeetingMinder, if there is not already an issue open, please first discuss the change you wish to make via issue before making a change. 
+When contributing to MeetingMinder, if there is not already an issue open, please first discuss the change you wish to make via an issue before making a change. 
 
 Please note we have a [code of conduct](https://github.com/SocexSolutions/agenda-v2/blob/master/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Agenda
+# MeetingMinder
+ [![License](https://img.shields.io/static/v1?label=license&message=MIT&color=brightgreen)](https://github.com/airbytehq/airbyte/tree/a9b1c6c0420550ad5069aca66c295223e0d05e27/LICENSE/README.md) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
 
-Agenda will allow for more efficient meetings by establishing meeting topics in advance, determining each topics value, and then deciding on the order and allocating time to the topics based on their value. In addition, agenda will simplify meeting notes avoiding TLDR through action items for each topic.
+MeetingMinder will allow for more efficient meetings by establishing meeting topics in advance, determining each topics value, and then deciding on the order and allocating time to the topics based on their value. In addition, agenda will simplify meeting notes avoiding TLDR through action items for each topic.
 
 # Getting Started
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,29 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules


### PR DESCRIPTION
Added community documents both for our own reference and for the reference of outside contributors

## Sources
- Issue remplate - https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
- PR template - https://github.com/axolo-co/pull_request_template
- Code of conduct - https://www.contributor-covenant.org/
- Contributing - written by me