### PR TITLE
Indexes for Inbox Query

### DIFF
--- a/api/lib/models/meeting.js
+++ b/api/lib/models/meeting.js
@@ -15,6 +15,7 @@ const meetingSchema = new Schema(
     date: {
       type: Date,
       required: true,
+      index: -1,
     },
     status: {
       type: String,

--- a/api/lib/models/participant.js
+++ b/api/lib/models/participant.js
@@ -5,6 +5,7 @@ const participantSchema = new mongoose.Schema(
   {
     email: {
       type: String,
+      index: true,
       required: true,
     },
     meeting_id: {

--- a/api/lib/models/user.js
+++ b/api/lib/models/user.js
@@ -5,6 +5,7 @@ const userSchema = new mongoose.Schema(
     email: {
       type: String,
       required: true,
+      index: true,
     },
     username: {
       type: String,


### PR DESCRIPTION
### Context

While reviewing for my interview I read through MongoDb's docs on indexes and noticed that there are a few places where we should have indexes but we don't. This pr adds those indexes.

### Implementation

- Added a descending index on meeting date since we sort by meeting date by default.
- Added indexes to the `email` field of the participant and user models since we use them in the join for the inbox query.