### PR TITLE
HttpOnly SameSite Cookies & Fix Logo Ref

### DIFF
--- a/www/components/Layout/Nav/Nav.js
+++ b/www/components/Layout/Nav/Nav.js
@@ -101,7 +101,7 @@ const Nav = () => {
         <nav className={styles.nav}>
           <Link href="/">
             <div className={styles.agenda}>
-              <img src="./logo.png" alt="Agenda" className={styles.logo} />
+              <img src="/logo.png" alt="Agenda" className={styles.logo} />
             </div>
           </Link>
           <div className={styles.login}>

--- a/www/pages/_app.js
+++ b/www/pages/_app.js
@@ -24,7 +24,7 @@ const pagesNeedingAuth = new Set([
   "user",
   "meet",
   "edit",
-  "voting",
+  "vote",
   "home",
 ]);
 
@@ -49,7 +49,9 @@ const App = (props) => {
       }
     }
 
-    refresh();
+    if (!store.getState().user.loggedOut) {
+      refresh();
+    }
   }, [user]);
 
   const Component = props.Component;

--- a/www/pages/api/[...slug].js
+++ b/www/pages/api/[...slug].js
@@ -41,7 +41,7 @@ export default async (req, res) => {
         `Set-Cookie`,
         `agenda-auth=${data.token}; path=/; Expires=${new Date(
           Date.now() + oneWeekMS
-        )}; HttpOnly`
+        )}; HttpOnly; SameSite=Strict;`
       );
 
       return res.status(200).json(data);
@@ -54,7 +54,9 @@ export default async (req, res) => {
   if (req.url === "/api/user/logout") {
     res.setHeader(
       `Set-Cookie`,
-      `agenda-auth=''; path=/; Expires=${new Date(0)}; HttpOnly`
+      `agenda-auth=''; path=/; Expires=${new Date(
+        0
+      )}; HttpOnly; SameSite=Strict;`
     );
 
     return res.status(200).send("ok");

--- a/www/pages/api/[...slug].js
+++ b/www/pages/api/[...slug].js
@@ -35,9 +35,13 @@ export default async (req, res) => {
     try {
       const data = await proxyRequest(req);
 
+      const oneWeekMS = 1000 * 60 * 60 * 24 * 7;
+
       res.setHeader(
         `Set-Cookie`,
-        `agenda-auth=${data.token}; path=/; HttpOnly`
+        `agenda-auth=${data.token}; path=/; Expires=${new Date(
+          Date.now() + oneWeekMS
+        )}; HttpOnly`
       );
 
       return res.status(200).json(data);
@@ -45,6 +49,15 @@ export default async (req, res) => {
       console.error(err.message);
       return res.status(500).send(err);
     }
+  }
+
+  if (req.url === "/api/user/logout") {
+    res.setHeader(
+      `Set-Cookie`,
+      `agenda-auth=''; path=/; Expires=${new Date(0)}; HttpOnly`
+    );
+
+    return res.status(200).send("ok");
   }
 
   try {

--- a/www/store/features/user.js
+++ b/www/store/features/user.js
@@ -1,11 +1,11 @@
 import client from "../../api/client";
-import { setCookie } from "../../utils/cookie";
 import router from "next/router";
 
 const initialState = {
   _id: null,
   username: null,
   email: null,
+  loggedOut: false,
 };
 
 const reducer = (state = initialState, action) => {
@@ -106,11 +106,11 @@ export const userRefresh = () => {
  */
 export const userLogout = () => {
   return async function logoutUser(dispatch) {
-    setCookie("agenda-auth", "");
+    await client.get("user/logout");
 
     dispatch({
       type: "user/logout",
-      payload: {},
+      payload: { loggedOut: true },
     });
 
     router.push("/");


### PR DESCRIPTION
Another realization while prepping for the interview. Since we now just use cookies and proxy requests through the web server, it is trivial to use `HttpOnly` cookies which make cross site scripting even more difficult (you can't access them with js in the browser).