### PR TITLE
Use access_token in authentication response payload

### DIFF
--- a/api/lib/controllers/user.js
+++ b/api/lib/controllers/user.js
@@ -76,7 +76,7 @@ module.exports = {
           email: user.email,
           username: user.username,
         },
-        token,
+        access_token: token,
         expiresIn,
       });
     } else {

--- a/api/test/tests/controllers/user.test.js
+++ b/api/test/tests/controllers/user.test.js
@@ -33,6 +33,7 @@ describe("lib/controllers/user.js", () => {
   });
 
   after(async () => {
+    await dbUtils.clean();
     await api.stop();
     await db.disconnect();
   });
@@ -50,6 +51,14 @@ describe("lib/controllers/user.js", () => {
 
       assert.strictEqual(res.data.user.email, "email");
       assert.strictEqual(res.data.user.username, "thudson");
+    });
+
+    it("should return an access_token", async () => {
+      const res = await client.post(path, user);
+
+      assert.exists(res.data.access_token);
+      assert.equal(res.data.access_token.length, 815);
+      assert.equal(res.data.access_token.split(".").length, 3);
     });
 
     it("should not register a user with an existing username", async () => {
@@ -123,6 +132,17 @@ describe("lib/controllers/user.js", () => {
       const res = await client.post(path, loginCreds);
 
       assert(res.status === 200);
+
+      assert.equal(res.data.user.username, user.username);
+      assert.equal(res.data.user.email, user.email);
+    });
+
+    it("should return an access_token", async () => {
+      const res = await client.post(path, user);
+
+      assert.exists(res.data.access_token);
+      assert.equal(res.data.access_token.length, 815);
+      assert.equal(res.data.access_token.split(".").length, 3);
     });
 
     it("should not login user with invalid password", async () => {

--- a/www/pages/api/[...slug].js
+++ b/www/pages/api/[...slug].js
@@ -38,7 +38,7 @@ export default async (req, res) => {
 
       res.setHeader(
         `Set-Cookie`,
-        `agenda-auth=${data.token}; path=/; Expires=${new Date(
+        `agenda-auth=${data.access_token}; path=/; Expires=${new Date(
           Date.now() + oneWeekMS
         )}; HttpOnly; SameSite=Strict;`
       );


### PR DESCRIPTION
## Description

<!-- Links to Proposal, Issues, Tickets -->

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I modified the register method to use `access_token` as apposed to `token` in the authentication payload since that is what is recommended in the spec. Looks like I didn't do that for the login route and our tests didn't catch anything not working. I added some new tests to validate the jwt being returned which should make this less likely in the future. Obviously an E2E test would be better but I'm not sure how we want to do that.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
