### PR TITLE
fix(www:meet): preserve whitespace in topic display

### DIFF
--- a/www/components/pages/Meet/TopicDisplay/TopicDisplay.module.scss
+++ b/www/components/pages/Meet/TopicDisplay/TopicDisplay.module.scss
@@ -24,3 +24,7 @@
 .topic_name {
   margin: 0;
 }
+
+.topic_description {
+  white-space: pre;
+}


### PR DESCRIPTION
## Description

<!-- Links to Proposal, Issues, Tickets -->

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The Topic display had previously been collapsing the descriptions of topics ie. newlines were not being preserved. This pr fixes that issue.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
