### PR TITLE
fix(www:drawer): no button text wrapping

### DIFF
--- a/www/components/Layout/Drawer/Drawer.module.scss
+++ b/www/components/Layout/Drawer/Drawer.module.scss
@@ -7,20 +7,22 @@
 
   .drawer {
     width: 15em;
-    transition: width 200ms ease;
+    transition: all 200ms ease;
     overflow: hidden;
     background: colors.$foreground;
     border-right: 1px solid colors.$border;
   }
 
   .closed {
-    width: 0em;
+    width: 0;
+    transform: translate(-15em, 0);
   }
 
   .icon_button {
     font-size: 20px;
     text-transform: capitalize;
     width: 100%;
+    min-width: 200px;
     padding: 0.5em 0em 0.5em 2em;
     justify-content: flex-start;
     color: colors.$midText;


### PR DESCRIPTION
## Description

<!-- Links to Proposal, Issues, Tickets -->

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The drawer is currently a little bit weird in that when it collapses the action item button momentarily displays as two lines before disappearing. This pr fixes the issue by adding a minimum width for the button. To make the drawer seem more natural, I also added a translation so that the buttons move in the direction that the drawer is being closed.

**Current Behavior:**

https://user-images.githubusercontent.com/54583311/206501552-c189be15-7308-4be6-9b15-75900be82af7.mov

**New Behavior:**

https://user-images.githubusercontent.com/54583311/206501632-b9f83ce3-9b94-4ba0-82f8-bfdb8f2baefe.mov

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
