### PR TITLE
fix(www:inbox): default meeting name

### DIFF
--- a/www/components/pages/Home/Inbox/Inbox.module.scss
+++ b/www/components/pages/Home/Inbox/Inbox.module.scss
@@ -1,4 +1,4 @@
-@use '../../../../styles/colors.scss';
+@use "../../../../styles/colors.scss";
 
 .table {
   width: 100%;
@@ -9,10 +9,10 @@
   //padding: 1em;
 }
 
-.filter_box{
+.filter_box {
   background-color: colors.$background;
   height: 3em;
-  transition: height .2s;
+  transition: height 0.2s;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -24,27 +24,26 @@
   .visible {
     display: flex;
     align-items: center;
-    margin-top: .3em;
+    margin-top: 0.3em;
     gap: 0.7em;
   }
 
   .hidden {
-    margin-top: .7em;
+    margin-top: 0.7em;
   }
 }
 
 .filter_box_open {
-  transition: height .2s;
+  transition: height 0.2s;
   height: 10em;
 }
 
 .row {
-  padding: .75em .5em;
-  margin: 0 .5em 0 .5em;
-  width: 98%;
   border-top: 1px solid colors.$border;
 
+  // Padding must be added to p in order for it to be clickable.
   p {
+    padding: 0.75em;
     margin: 0;
   }
 

--- a/www/components/pages/Home/Inbox/InboxRow/InboxRow.js
+++ b/www/components/pages/Home/Inbox/InboxRow/InboxRow.js
@@ -10,9 +10,12 @@ import { useState } from "react";
 export default function InboxRow({ meeting, refresh, classes }) {
   const [open, setOpen] = useState(false);
 
+  // Name must exist in order for meeting to be clickable.
+  const name = meeting.name || "Draft";
+
   return (
     <div className={classes}>
-      <p onClick={() => setOpen(true)}>{meeting.name}</p>
+      <p onClick={() => setOpen(true)}>{name}</p>
       <MeetingModal
         meeting={meeting}
         open={open}


### PR DESCRIPTION
## Description

<!-- Links to Proposal, Issues, Tickets -->

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When a meeting has no name it doesn't have a clickable box used to open it. This PR modifies the inbox to provide a default so that all meetings can be selected and also makes the box larger so that they are easier to click.

**Current Behavior:**

https://user-images.githubusercontent.com/54583311/206508244-d7af9744-142a-4c4f-aeb5-13cd83728f0b.mov

**New Behavior:**

https://user-images.githubusercontent.com/54583311/206508647-0997e6db-caeb-4307-b953-0e5b14444cba.mov


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
