### PR TITLE
feat(www:edit): refactor edit page to use new temp id pattern

### DIFF
--- a/www/components/pages/Edit/TopicBoard/TopicBoard.js
+++ b/www/components/pages/Edit/TopicBoard/TopicBoard.js
@@ -1,0 +1,72 @@
+import { Button, Fade } from "@mui/material";
+
+import TopicCard from "../../../shared/TopicCard/TopicCard";
+
+import meetingStore from "../../../../store/features/meeting";
+
+import { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import styles from "./TopicBoard.module.scss";
+
+export default function TopicBoard({ meetingId }) {
+  const dispatch = useDispatch();
+
+  const [unsavedTopics, setUnsavedTopics] = useState([]);
+
+  useEffect(() => {
+    dispatch(meetingStore.actions.getTopics(meetingId));
+  }, []);
+
+  const topics = useSelector((state) =>
+    meetingStore.selectors.topics(state, meetingId)
+  );
+
+  const sorted = topics.concat(unsavedTopics).sort((a, b) => {
+    if (!a.createdAt) {
+      return 1;
+    } else if (!b.createdAt) {
+      return -1;
+    } else {
+      return new Date(a.createdAt) - new Date(b.createdAt);
+    }
+  });
+
+  const cards = sorted.map((topic) => {
+    return (
+      <TopicCard
+        key={JSON.stringify(topic)}
+        topic={topic}
+        deleteUnsaved={(id) => {
+          setUnsavedTopics(unsavedTopics.filter((t) => t._id !== id));
+        }}
+        className={styles.topicCard}
+      />
+    );
+  });
+
+  return (
+    <div className={styles.topic_board}>
+      <Fade in={cards.length !== 0}>
+        <div className={styles.cards_container}>{cards}</div>
+      </Fade>
+      <Button
+        variant="contained"
+        color="primary"
+        className={styles.addTopicButton}
+        onClick={() => {
+          const newTopic = {
+            _id: `temp-${Math.random()}`,
+            meeting_id: meetingId,
+            name: "",
+            description: "",
+          };
+          setUnsavedTopics([...unsavedTopics, newTopic]);
+        }}
+        disableElevation
+      >
+        Add Topic
+      </Button>
+    </div>
+  );
+}

--- a/www/components/pages/Edit/TopicBoard/TopicBoard.module.scss
+++ b/www/components/pages/Edit/TopicBoard/TopicBoard.module.scss
@@ -1,0 +1,6 @@
+.cards_container {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  margin: 1em 0;
+}

--- a/www/components/shared/TopicCard/TopicCard.js
+++ b/www/components/shared/TopicCard/TopicCard.js
@@ -1,0 +1,124 @@
+import { TextField, Button } from "@mui/material";
+
+import QuestionAnswerIcon from "@mui/icons-material/QuestionAnswer";
+
+import topicStore from "../../../store/features/topic";
+
+import { useState } from "react";
+import { useDispatch } from "react-redux";
+
+import styles from "./TopicCard.module.scss";
+
+export default function TopicCard({ topic, deleteUnsaved, className }) {
+  const dispatch = useDispatch();
+
+  const [editing, setEditing] = useState(topic._id.includes("temp"));
+  const [name, setName] = useState(topic.name);
+  const [description, setDescription] = useState(topic.description);
+
+  const onSave = () => {
+    setEditing(false);
+
+    // When a topic is created, it receives a temp id until it is saved.
+    // Thus, if the topic has an id starting with temp, we need to create
+    // it.
+    if (topic._id.startsWith("temp")) {
+      dispatch(
+        topicStore.actions.create({
+          meeting_id: topic.meeting_id,
+          name,
+          description,
+        })
+      );
+
+      deleteUnsaved(topic._id);
+    } else {
+      dispatch(
+        topicStore.actions.update({
+          _id: topic._id,
+          meeting_id: topic.meeting_id,
+          name,
+          description,
+        })
+      );
+    }
+  };
+
+  const onDelete = () => {
+    // When a topic is created, it receives a temp id until it is saved.
+    // Thus, if the topic has an id starting with temp, we can just delete
+    // it from the store.
+    if (topic._id.startsWith("temp")) {
+      deleteUnsaved(topic._id);
+    } else {
+      dispatch(topicStore.actions.delete(topic));
+    }
+  };
+
+  const maybeHandleShortcut = (e) => {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      onSave();
+    }
+  };
+
+  if (!editing) {
+    return (
+      <div
+        className={`${styles.card} ${styles.clickable} ${className}`}
+        onClick={() => setEditing(true)}
+      >
+        <div className={styles.content_container}>
+          <h4 className={styles.name}>{name}</h4>
+          {description && <p className={styles.description}>{description}</p>}
+        </div>
+        <div className={styles.icon_container}>
+          <QuestionAnswerIcon color="primary" className={styles.icon} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`${styles.card} ${className}`}>
+      <div className={styles.content_container}>
+        <TextField
+          label="Name"
+          variant="outlined"
+          size="small"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={maybeHandleShortcut}
+          className={styles.name_input}
+        />
+        <TextField
+          label="Description"
+          variant="outlined"
+          size="small"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          onKeyDown={maybeHandleShortcut}
+          className={styles.description_input}
+          multiline
+          minRows={3}
+        />
+        <div className={styles.button_container}>
+          <Button onClick={() => onDelete()} size="small" color={"red"}>
+            delete
+          </Button>
+          <Button
+            disabled={!name}
+            onClick={() => onSave()}
+            size="small"
+            variant="contained"
+            disableElevation
+          >
+            save
+          </Button>
+        </div>
+      </div>
+      <div className={styles.icon_container}>
+        <QuestionAnswerIcon color="primary" className={styles.icon} />
+      </div>
+    </div>
+  );
+}

--- a/www/components/shared/TopicCard/TopicCard.module.scss
+++ b/www/components/shared/TopicCard/TopicCard.module.scss
@@ -1,0 +1,55 @@
+.card {
+  display: flex;
+  color: var(--darkText);
+  border: 1px solid var(--border);
+  background: var(--foreground);
+  border-radius: 6px;
+  padding: 1em;
+
+  p {
+    white-space: pre-wrap;
+  }
+
+  @media only screen and (max-width: 600px) {
+    min-width: 90px;
+  }
+
+  &.clickable {
+    cursor: pointer;
+
+    &:hover {
+      background: var(--foregroundHighlight);
+    }
+  }
+}
+
+.icon_container {
+  display: flex;
+  justify-content: center;
+  padding-left: 0.5em;
+  width: 2.5em;
+}
+
+.content_container {
+  width: 100%;
+}
+
+.name_input {
+  margin-bottom: 1em;
+  width: 30%;
+  min-width: 200px;
+}
+
+.description_input {
+  margin-bottom: 1em;
+  width: 100%;
+}
+
+.button_container {
+  display: flex;
+  justify-content: flex-end;
+
+  button {
+    margin-left: 0.5em;
+  }
+}

--- a/www/pages/meeting/[id]/edit.js
+++ b/www/pages/meeting/[id]/edit.js
@@ -1,14 +1,12 @@
 import HeaderForm from "../../../components/pages/Edit/HeaderForm/HeaderForm";
 import StatusButton from "../../../components/pages/Edit/StatusButton/StatusButton";
-import CardBoard from "../../../components/shared/CardBoard/CardBoard";
 import ChipForm from "../../../components/shared/ChipForm/ChipForm";
-import CardForm from "../../../components/shared/CardForm/CardForm";
 import LoadingIcon from "../../../components/shared/LoadingIcon/LoadingIcon";
+import TopicBoard from "../../../components/pages/Edit/TopicBoard/TopicBoard";
 
 import { Fade } from "@mui/material";
 
 import meetingStore from "../../../store/features/meeting";
-import topicStore from "../../../store/features/topic";
 import participantStore from "../../../store/features/participant";
 
 import { useRouter } from "next/router";
@@ -111,23 +109,7 @@ const Meeting = (props) => {
             }
           >
             <h3>Topics</h3>
-            <CardBoard
-              selector={(state) =>
-                meetingStore.selectors.topics(state, meeting_id)
-              }
-              create={(payload) =>
-                dispatch(
-                  topicStore.actions.create({
-                    meeting_id,
-                    ...payload,
-                  })
-                )
-              }
-              update={(item) => dispatch(topicStore.actions.update(item))}
-              destroy={(item) => dispatch(topicStore.actions.delete(item))}
-              Card={CardForm}
-              itemName={"Topic"}
-            />
+            <TopicBoard meetingId={meeting_id} />
           </section>
         </div>
       </div>

--- a/www/styles/globals.css
+++ b/www/styles/globals.css
@@ -71,6 +71,7 @@ p {
   --background: #f5f5f5;
   --backgroundHighlight: #e6e6e6;
   --foreground: #fff;
+  --foregroundHighlight: #f0f0f0;
   --border: #c9c9c9;
   --darkText: #3a3c45;
   --midText: #6a737d;


### PR DESCRIPTION
## Description

<!-- Links to Proposal, Issues, Tickets -->

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This pr modifies the meeting edit page so that it doesn't create new empty topics each time that the user clicks add topic. Instead, the topic state is stored locally and is identified with an id prefixed with `temp`. I also added a new `TopicCard` component specific to topics that has a unique topic icon. This should make it easy for the user to differentiate between each type of item.

**Preview:**

https://user-images.githubusercontent.com/54583311/206785745-1d624a7c-e958-4688-94bd-9d74df6b7cac.mov

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Housekeeping and refactoring

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->

Just did some simple manual test to check that crud operations on topics still work.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
