### PR TITLE
Fix Create Fab Fade

### DIFF
--- a/www/pages/user/[id]/home.js
+++ b/www/pages/user/[id]/home.js
@@ -89,27 +89,29 @@ export default function Home({ store }) {
   }, [debouncedFilters, page]);
 
   return (
-    <Fade in={!loading}>
-      <div className={shared.page}>
-        <div className={shared.container}>
-          <h2 className={styles.page_title}>My Meetings</h2>
-          <Inbox
-            meetings={meetings}
-            owners={owners}
-            refresh={() => load()}
-            rowsPerPage={rowsPerPage}
-            setRowsPerPage={setRowsPerPage}
-            setFilters={setFilters}
-            filters={filters}
-            totalMeetings={meetingCount}
-            page={page}
-            setPage={setPage}
-            loading={loading}
-          />
-        </div>
-
-        <CreateFab />
+    <div className={shared.page}>
+      <div className={shared.container}>
+        <h2 className={styles.page_title}>My Meetings</h2>
+        <Fade in={!loading}>
+          <div>
+            <Inbox
+              meetings={meetings}
+              owners={owners}
+              refresh={() => load()}
+              rowsPerPage={rowsPerPage}
+              setRowsPerPage={setRowsPerPage}
+              setFilters={setFilters}
+              filters={filters}
+              totalMeetings={meetingCount}
+              page={page}
+              setPage={setPage}
+              loading={loading}
+            />
+          </div>
+        </Fade>
       </div>
-    </Fade>
+
+      <CreateFab />
+    </div>
   );
 }


### PR DESCRIPTION
## Description

The create button on the home page fades in and out when the table is reloaded which doesn't make sense. This pr prevents that behavior.

## Preview

### Before

https://user-images.githubusercontent.com/54583311/212727798-0b4e0ce1-0fb9-40dd-8641-6924212ffeb2.mov

### After

https://user-images.githubusercontent.com/54583311/212728000-dfb89e53-eaf1-4897-9bee-2cfda9063fca.mov

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Just tested that the create fab still works as intended and that it remains visible through the process of loading new meetings.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
